### PR TITLE
Dropping Unneeded Type Casts

### DIFF
--- a/src/collections/waker_page.rs
+++ b/src/collections/waker_page.rs
@@ -120,7 +120,7 @@ impl WakerPageRef {
 
         unsafe {
             let base_ptr: *mut u8 = self.0.as_ptr().cast();
-            let ptr = NonNull::new_unchecked(base_ptr.offset(ix as isize));
+            let ptr = NonNull::new_unchecked(base_ptr.add(ix));
             WakerRef(ptr)
         }
     }

--- a/src/protocols/icmpv4/peer.rs
+++ b/src/protocols/icmpv4/peer.rs
@@ -156,7 +156,7 @@ impl<RT: Runtime> Icmpv4Peer<RT> {
     ) -> impl Future<Output = Result<Duration, Fail>> {
         let timeout = timeout.unwrap_or_else(|| Duration::from_millis(5000));
         let id = {
-            let mut state = 0xFFFF as u32;
+            let mut state: u32 = 0xFFFF;
             let addr_octets = self.rt.local_ipv4_addr().octets();
             state += NetworkEndian::read_u16(&addr_octets[0..2]) as u32;
             state += NetworkEndian::read_u16(&addr_octets[3..4]) as u32;

--- a/src/protocols/tcp/active_open.rs
+++ b/src/protocols/tcp/active_open.rs
@@ -181,13 +181,13 @@ impl<RT: Runtime> ActiveOpenSocket<RT> {
         // TODO(RFC1323): Clamp the scale to 14 instead of panicking.
         assert!(local_window_scale <= 14 && remote_window_scale <= 14);
 
-        let rx_window_size: u32 = (tcp_options.receive_window_size as u32)
+        let rx_window_size: u32 = (tcp_options.receive_window_size)
             .checked_shl(local_window_scale as u32)
             .expect("TODO: Window size overflow")
             .try_into()
             .expect("TODO: Window size overflow");
 
-        let tx_window_size: u32 = (header.window_size as u32)
+        let tx_window_size: u32 = (header.window_size)
             .checked_shl(remote_window_scale as u32)
             .expect("TODO: Window size overflow")
             .try_into()

--- a/src/protocols/tcp/passive_open.rs
+++ b/src/protocols/tcp/passive_open.rs
@@ -173,7 +173,7 @@ impl<RT: Runtime> PassiveSocket<RT> {
                 Some(w) => (tcp_options.window_scale as u32, w),
                 None => (0, 0),
             };
-            let remote_window_size = (header_window_size as u32)
+            let remote_window_size = (header_window_size)
                 .checked_shl(remote_window_scale as u32)
                 .expect("TODO: Window size overflow")
                 .try_into()


### PR DESCRIPTION
# Description

In this Pull Request I fix build warnings for unneeded type casts.