### PR TITLE
Don't Using Map Unit Function

### DIFF
--- a/src/protocols/tcp/active_open.rs
+++ b/src/protocols/tcp/active_open.rs
@@ -115,7 +115,7 @@ impl<RT: Runtime> ActiveOpenSocket<RT> {
 
     fn set_result(&mut self, result: Result<ControlBlock<RT>, Fail>) {
         let mut r = self.result.borrow_mut();
-        r.waker.take().map(|w| w.wake());
+        if let Some(w) = r.waker.take() { w.wake() }
         r.result.replace(result);
     }
 

--- a/src/protocols/tcp/active_open.rs
+++ b/src/protocols/tcp/active_open.rs
@@ -265,7 +265,7 @@ impl<RT: Runtime> ActiveOpenSocket<RT> {
                 rt.wait(handshake_timeout).await;
             }
             let mut r = result.borrow_mut();
-            r.waker.take().map(|w| w.wake());
+            if let Some(w) = r.waker.take() { w.wake() }
             r.result.replace(Err(Fail::Timeout {}));
         }
     }

--- a/src/protocols/tcp/established/state/receiver.rs
+++ b/src/protocols/tcp/established/state/receiver.rs
@@ -239,7 +239,7 @@ impl<RT: Runtime> Receiver<RT> {
 
         self.recv_seq_no.modify(|r| r + Wrapping(buf.len() as u32));
         self.recv_queue.borrow_mut().push_back(buf);
-        self.waker.borrow_mut().take().map(|w| w.wake());
+        if let Some(w) = self.waker.borrow_mut().take() { w.wake() }
 
         // TODO: How do we handle when the other side is in PERSIST state here?
         if self.ack_deadline.get().is_none() {

--- a/src/protocols/tcp/passive_open.rs
+++ b/src/protocols/tcp/passive_open.rs
@@ -73,12 +73,12 @@ impl<RT: Runtime> ReadySockets<RT> {
     fn push_ok(&mut self, cb: ControlBlock<RT>) {
         assert!(self.endpoints.insert(cb.remote));
         self.ready.push_back(Ok(cb));
-        self.waker.take().map(|w| w.wake());
+        if let Some(w) = self.waker.take() { w.wake() }
     }
 
     fn push_err(&mut self, err: Fail) {
         self.ready.push_back(Err(err));
-        self.waker.take().map(|w| w.wake());
+        if let Some(w) = self.waker.take() { w.wake() }
     }
 
     fn poll(&mut self, ctx: &mut Context) -> Poll<Result<ControlBlock<RT>, Fail>> {

--- a/src/protocols/udp/peer.rs
+++ b/src/protocols/udp/peer.rs
@@ -204,7 +204,7 @@ impl<RT: Runtime> UdpPeer<RT> {
         })?;
         let mut l = listener.borrow_mut();
         l.buf.push_back((remote, data));
-        l.waker.take().map(|w| w.wake());
+        if let Some(w) = l.waker.take() { w.wake() }
         Ok(())
     }
 


### PR DESCRIPTION
# Description

In this Pull Request I fix build warnings for using map unit functions.