### PR TITLE
Don't Use Clone When Copying is Available

### DIFF
--- a/src/protocols/tcp/active_open.rs
+++ b/src/protocols/tcp/active_open.rs
@@ -205,8 +205,8 @@ impl<RT: Runtime> ActiveOpenSocket<RT> {
         let sender = Sender::new(expected_seq, tx_window_size, remote_window_scale, mss);
         let receiver = Receiver::new(remote_seq_num, rx_window_size, local_window_scale);
         let cb = ControlBlock {
-            local: self.local.clone(),
-            remote: self.remote.clone(),
+            local: self.local,
+            remote: self.remote,
             rt: self.rt.clone(),
             arp: self.arp.clone(),
             sender,

--- a/src/protocols/tcp/active_open.rs
+++ b/src/protocols/tcp/active_open.rs
@@ -81,8 +81,8 @@ impl<RT: Runtime> ActiveOpenSocket<RT> {
 
         let future = Self::background(
             local_isn,
-            local.clone(),
-            remote.clone(),
+            local,
+            remote,
             rt.clone(),
             arp.clone(),
             result.clone(),

--- a/src/protocols/tcp/established/mod.rs
+++ b/src/protocols/tcp/established/mod.rs
@@ -79,6 +79,6 @@ impl<RT: Runtime> EstablishedSocket<RT> {
     }
 
     pub fn endpoints(&self) -> (ipv4::Endpoint, ipv4::Endpoint) {
-        (self.cb.local.clone(), self.cb.remote.clone())
+        (self.cb.local, self.cb.remote)
     }
 }

--- a/src/protocols/tcp/passive_open.rs
+++ b/src/protocols/tcp/passive_open.rs
@@ -203,8 +203,8 @@ impl<RT: Runtime> PassiveSocket<RT> {
             );
             self.inflight.remove(&remote);
             let cb = ControlBlock {
-                local: self.local.clone(),
-                remote: remote.clone(),
+                local: self.local,
+                remote,
                 rt: self.rt.clone(),
                 arp: self.arp.clone(),
                 sender,

--- a/src/protocols/tcp/passive_open.rs
+++ b/src/protocols/tcp/passive_open.rs
@@ -231,7 +231,7 @@ impl<RT: Runtime> PassiveSocket<RT> {
             local_isn,
             remote_isn,
             self.local,
-            remote.clone(),
+            remote,
             self.rt.clone(),
             self.arp.clone(),
             self.ready.clone(),

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -150,8 +150,8 @@ impl<RT: Runtime> Peer<RT> {
         let key = (established.cb.local, established.cb.remote);
 
         let socket = Socket::Established {
-            local: established.cb.local.clone(),
-            remote: established.cb.remote.clone(),
+            local: established.cb.local,
+            remote: established.cb.remote,
         };
         assert!(inner.sockets.insert(fd, socket).is_none());
         assert!(inner.established.insert(key, established).is_none());
@@ -182,13 +182,13 @@ impl<RT: Runtime> Peer<RT> {
             let local = ipv4::Endpoint::new(inner.rt.local_ipv4_addr(), local_port);
 
             let socket = Socket::Connecting {
-                local: local.clone(),
-                remote: remote.clone(),
+                local,
+                remote,
             };
             inner.sockets.insert(fd, socket);
 
             let local_isn = inner.isn_generator.generate(&local, &remote);
-            let key = (local.clone(), remote.clone());
+            let key = (local, remote);
             let socket = ActiveOpenSocket::new(
                 local_isn,
                 local,

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -311,7 +311,7 @@ impl<RT: Runtime> Peer<RT> {
         let inner = self.inner.borrow_mut();
         match inner.sockets.get(&fd) {
             Some(Socket::Established { local, remote }) => {
-                let key = (local.clone(), remote.clone());
+                let key = (*local, *remote);
                 match inner.established.get(&key) {
                     Some(ref s) => s.close()?,
                     None => {

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -114,7 +114,7 @@ impl<RT: Runtime> Peer<RT> {
         }
 
         let socket = PassiveSocket::new(local, backlog, inner.rt.clone(), inner.arp.clone());
-        assert!(inner.passive.insert(local.clone(), socket).is_none());
+        assert!(inner.passive.insert(local, socket).is_none());
         inner.sockets.insert(fd, Socket::Listening { local });
         Ok(())
     }

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -147,7 +147,7 @@ impl<RT: Runtime> Peer<RT> {
         };
         let fd = inner.file_table.alloc(File::TcpSocket);
         let established = EstablishedSocket::new(cb, fd, inner.dead_socket_tx.clone());
-        let key = (established.cb.local.clone(), established.cb.remote.clone());
+        let key = (established.cb.local, established.cb.remote);
 
         let socket = Socket::Established {
             local: established.cb.local.clone(),

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -225,11 +225,11 @@ impl Runtime for TestRuntime {
     }
 
     fn local_link_addr(&self) -> MacAddress {
-        self.inner.borrow().link_addr.clone()
+        self.inner.borrow().link_addr
     }
 
     fn local_ipv4_addr(&self) -> Ipv4Addr {
-        self.inner.borrow().ipv4_addr.clone()
+        self.inner.borrow().ipv4_addr
     }
 
     fn tcp_options(&self) -> tcp::Options {


### PR DESCRIPTION
# Description

In this Pull Request I fix build warnings for usage of clone instead of copying.