### PR TITLE
Disabling ARP Cache Eviction

### DIFF
--- a/src/protocols/arp/peer.rs
+++ b/src/protocols/arp/peer.rs
@@ -64,7 +64,8 @@ impl<RT: Runtime> ArpPeer<RT> {
             {
                 let mut cache = cache.borrow_mut();
                 cache.advance_clock(current_time);
-                cache.clear();
+                // TODO: re-enable eviction once TCP/IP stack is fully functional.
+                // cache.clear();
             }
             rt.wait(Duration::from_secs(1)).await;
         }


### PR DESCRIPTION
# Description

ARP cache eviction is causing TCP to misbehave. In this commit I temporarily disable this feature.