### PR TITLE
Add an example runtime which uses a linux raw socket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-traits = "0.2.14"
 pin-project = "1.0.7"
 rand = { version = "0.8.4", features = ["small_rng"] }
 slab = "0.4.3"
+socket2 = { version = "0.4.1", features = ["all"] }
 unicycle = { git = "https://github.com/sujayakar/unicycle", rev = "44c0e8f62cb9355cfd35ef5309abf10a4c388b62" }
 uniset = "0.2.0"
 async-trait = "0.1.50"

--- a/src/examples/linux_runtime.rs
+++ b/src/examples/linux_runtime.rs
@@ -1,0 +1,348 @@
+use crate::{collections::bytes::{
+        Bytes,
+        BytesMut
+    },
+    interop::{
+        dmtr_sgarray_t,
+        dmtr_sgaseg_t
+    },
+    protocols::{
+        arp,
+        ethernet2::{
+            Ethernet2Header,
+            MacAddress
+        },
+        tcp,
+        udp
+    },
+    runtime::{
+        PacketBuf,
+        RECEIVE_BATCH_SIZE,
+        Runtime
+    },
+    scheduler::{
+        Operation,
+        Scheduler,
+        SchedulerHandle
+    },
+    timer::{
+        Timer,
+        TimerRc,
+        WaitFuture
+    }
+};
+
+use arrayvec::ArrayVec;
+use futures::{Future, FutureExt};
+use libc;
+
+use rand::{
+    Rng,
+    SeedableRng,
+    distributions::Standard,
+    prelude::Distribution,
+    rngs::SmallRng,
+    seq::SliceRandom
+};
+use socket2::{Domain, SockAddr, Socket, Type};
+
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    convert::TryInto,
+    fs,
+    mem::{
+        self,
+        MaybeUninit
+    },
+    net::Ipv4Addr,
+    ptr,
+    rc::Rc,
+    slice,
+    time::{
+        Duration,
+        Instant
+    }
+};
+
+
+//==============================================================================
+// Constants & Structures
+//==============================================================================
+
+// ETH_P_ALL must be converted to big-endian short but (due to a bug in Rust libc bindings) comes as an int.
+const ETH_P_ALL: libc::c_ushort = (libc::ETH_P_ALL as libc::c_ushort).to_be();
+enum SockAddrPurpose {
+    Bind,
+    Send
+}
+
+#[derive(Clone)]
+pub struct LinuxRuntime {
+    inner: Rc<RefCell<Inner>>,
+    scheduler: Scheduler<Operation<LinuxRuntime>>,
+}
+
+pub struct Inner {
+    pub timer: TimerRc,
+    pub rng: SmallRng,
+    pub socket: Socket,
+    pub ifindex: i32,
+    pub link_addr: MacAddress,
+    pub ipv4_addr: Ipv4Addr,
+    pub tcp_options: tcp::Options<LinuxRuntime>,
+    pub arp_options: arp::Options,
+}
+
+
+//==============================================================================
+// Associate Functions
+//==============================================================================
+
+impl SockAddrPurpose {
+    fn protocol(&self) -> libc::c_ushort {
+        match self {
+            SockAddrPurpose::Bind => ETH_P_ALL,
+            SockAddrPurpose::Send => 0
+        }
+    }
+    fn halen(&self) -> libc::c_uchar {
+        match self {
+            SockAddrPurpose::Bind => 0,
+            SockAddrPurpose::Send => libc::ETH_ALEN.try_into().unwrap()
+        }
+    }
+
+}
+
+impl LinuxRuntime {
+    pub fn new(
+        now: Instant,
+        link_addr: MacAddress,
+        ipv4_addr: Ipv4Addr,
+        interface_name: &str,
+        arp: HashMap<Ipv4Addr, MacAddress>
+    ) -> Self {
+        let mut arp_options = arp::Options::default();
+        arp_options.retry_count = 2;
+        arp_options.cache_ttl = Duration::from_secs(600);
+        arp_options.request_timeout = Duration::from_secs(1);
+        arp_options.initial_values = arp;
+
+        let socket = Socket::new(Domain::PACKET, Type::RAW.nonblocking(), Some((ETH_P_ALL as libc::c_int).into())).unwrap();
+        let ifindex: i32 = fs::read_to_string(format!("/sys/class/net/{}/ifindex", interface_name)).expect("Could not read ifindex").parse().unwrap();
+
+        socket.bind(&raw_sockaddr(SockAddrPurpose::Bind, ifindex, &[0; 6])).unwrap();
+
+
+        let inner = Inner {
+            timer: TimerRc(Rc::new(Timer::new(now))),
+            rng: SmallRng::from_seed([0; 32]),
+            socket,
+            ifindex,
+            link_addr,
+            ipv4_addr,
+            tcp_options: tcp::Options::default(),
+            arp_options,
+        };
+        Self {
+            inner: Rc::new(RefCell::new(inner)),
+            scheduler: Scheduler::new(),
+        }
+    }
+}
+
+
+//==============================================================================
+// Trait Implementations
+//==============================================================================
+
+impl Runtime for LinuxRuntime {
+    type WaitFuture = WaitFuture<TimerRc>;
+    type Buf = Bytes;
+
+    fn into_sgarray(&self, buf: Bytes) -> dmtr_sgarray_t {
+        let buf_copy: Box<[u8]> = (&buf[..]).into();
+        let ptr = Box::into_raw(buf_copy);
+        let sgaseg = dmtr_sgaseg_t {
+            sgaseg_buf: ptr as *mut _,
+            sgaseg_len: buf.len() as u32,
+        };
+        dmtr_sgarray_t {
+            sga_buf: ptr::null_mut(),
+            sga_numsegs: 1,
+            sga_segs: [sgaseg],
+            sga_addr: unsafe { mem::zeroed() },
+        }
+    }
+
+    fn alloc_sgarray(&self, size: usize) -> dmtr_sgarray_t {
+        let allocation: Box<[u8]> = unsafe { Box::new_uninit_slice(size).assume_init() };
+        let ptr = Box::into_raw(allocation);
+        let sgaseg = dmtr_sgaseg_t {
+            sgaseg_buf: ptr as *mut _,
+            sgaseg_len: size as u32,
+        };
+        dmtr_sgarray_t {
+            sga_buf: ptr::null_mut(),
+            sga_numsegs: 1,
+            sga_segs: [sgaseg],
+            sga_addr: unsafe { mem::zeroed() },
+        }
+    }
+
+    fn free_sgarray(&self, sga: dmtr_sgarray_t) {
+        assert_eq!(sga.sga_numsegs, 1);
+        for i in 0..sga.sga_numsegs as usize {
+            let seg = &sga.sga_segs[i];
+            let allocation: Box<[u8]> = unsafe {
+                Box::from_raw(slice::from_raw_parts_mut(
+                    seg.sgaseg_buf as *mut _,
+                    seg.sgaseg_len as usize,
+                ))
+            };
+            drop(allocation);
+        }
+    }
+
+    fn clone_sgarray(&self, sga: &dmtr_sgarray_t) -> Bytes {
+        let mut len = 0;
+        for i in 0..sga.sga_numsegs as usize {
+            len += sga.sga_segs[i].sgaseg_len;
+        }
+        let mut buf = BytesMut::zeroed(len as usize);
+        let mut pos = 0;
+        for i in 0..sga.sga_numsegs as usize {
+            let seg = &sga.sga_segs[i];
+            let seg_slice = unsafe {
+                slice::from_raw_parts(seg.sgaseg_buf as *mut u8, seg.sgaseg_len as usize)
+            };
+            buf[pos..(pos + seg_slice.len())].copy_from_slice(seg_slice);
+            pos += seg_slice.len();
+        }
+        buf.freeze()
+    }
+
+    fn transmit(&self, pkt: impl PacketBuf<Bytes>) {
+        let header_size = pkt.header_size();
+        let body_size = pkt.body_size();
+
+        let mut buf = BytesMut::zeroed(header_size + body_size);
+
+        pkt.write_header(&mut buf[..header_size]);
+        if let Some(body) = pkt.take_body() {
+            buf[header_size..].copy_from_slice(&body[..]);
+        }
+
+        let buf = buf.freeze();
+        let (header, _) = Ethernet2Header::parse(buf.clone()).unwrap();
+        let dest_addr_arr = header.dst_addr.to_array();
+        let dest_sockaddr = raw_sockaddr(SockAddrPurpose::Send, self.inner.borrow().ifindex, &dest_addr_arr);
+
+        self.inner.borrow().socket.send_to(&buf, &dest_sockaddr).unwrap();
+    }
+
+    fn receive(&self) -> ArrayVec<Bytes, RECEIVE_BATCH_SIZE> {
+        // 4096B buffer size chosen arbitrarily, seems fine for now.
+        // This use-case is an example for MaybeUninit in the docs
+        let mut out: [MaybeUninit<u8>; 4096] = [unsafe { MaybeUninit::uninit().assume_init() }; 4096];
+        if let Ok((bytes_read, _origin_addr)) = self.inner.borrow().socket.recv_from(&mut out[..]) {
+            let mut ret = ArrayVec::new();
+            unsafe {
+                let out = mem::transmute::<[MaybeUninit<u8>; 4096], [u8; 4096]>(out);
+                ret.push(BytesMut::from(&out[..bytes_read]).freeze());
+            }
+            ret
+        } else {
+            ArrayVec::new()
+        }
+    }
+
+    fn scheduler(&self) -> &Scheduler<Operation<Self>> {
+        &self.scheduler
+    }
+
+    fn local_link_addr(&self) -> MacAddress {
+        self.inner.borrow().link_addr.clone()
+    }
+
+    fn local_ipv4_addr(&self) -> Ipv4Addr {
+        self.inner.borrow().ipv4_addr.clone()
+    }
+
+    fn tcp_options(&self) -> tcp::Options<Self> {
+        self.inner.borrow().tcp_options.clone()
+    }
+
+    fn udp_options(&self) -> udp::Options {
+        udp::Options::default()
+    }
+
+    fn arp_options(&self) -> arp::Options {
+        self.inner.borrow().arp_options.clone()
+    }
+
+    fn advance_clock(&self, now: Instant) {
+        self.inner.borrow_mut().timer.0.advance_clock(now);
+    }
+
+    fn wait(&self, duration: Duration) -> Self::WaitFuture {
+        let inner = self.inner.borrow_mut();
+        let now = inner.timer.0.now();
+        inner
+            .timer
+            .0
+            .wait_until(inner.timer.clone(), now + duration)
+    }
+
+    fn wait_until(&self, when: Instant) -> Self::WaitFuture {
+        let inner = self.inner.borrow_mut();
+        inner.timer.0.wait_until(inner.timer.clone(), when)
+    }
+
+    fn now(&self) -> Instant {
+        self.inner.borrow().timer.0.now()
+    }
+
+    fn rng_gen<T>(&self) -> T
+    where
+        Standard: Distribution<T>,
+    {
+        let mut inner = self.inner.borrow_mut();
+        inner.rng.gen()
+    }
+
+    fn rng_shuffle<T>(&self, slice: &mut [T]) {
+        let mut inner = self.inner.borrow_mut();
+        slice.shuffle(&mut inner.rng);
+    }
+
+    fn spawn<F: Future<Output = ()> + 'static>(&self, future: F) -> SchedulerHandle {
+        self.scheduler
+            .insert(Operation::Background(future.boxed_local()))
+    }
+}
+
+
+//==============================================================================
+// Helper Functions
+//==============================================================================
+
+fn raw_sockaddr(purpose: SockAddrPurpose, ifindex: i32, mac_addr: &[u8; 6]) -> SockAddr {
+    let mut padded_address = [0_u8; 8];
+    padded_address[..6].copy_from_slice(mac_addr);
+    let sockaddr_ll = libc::sockaddr_ll {
+        sll_family: libc::AF_PACKET.try_into().unwrap(),
+        sll_protocol: purpose.protocol(),
+        sll_ifindex: ifindex,
+        sll_hatype: 0,
+        sll_pkttype: 0,
+        sll_halen: purpose.halen(),
+        sll_addr: padded_address
+    };
+
+    unsafe {
+        let sockaddr_ptr = mem::transmute::<*const libc::sockaddr_ll, *const libc::sockaddr_storage>(&sockaddr_ll);
+        SockAddr::new(*sockaddr_ptr, mem::size_of::<libc::sockaddr_ll>().try_into().unwrap())
+    }
+}

--- a/src/examples/mod.rs
+++ b/src/examples/mod.rs
@@ -1,0 +1,1 @@
+pub mod linux_runtime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate derive_more;
 
 pub mod collections;
 pub mod engine;
+pub mod examples;
 pub mod fail;
 pub mod file_table;
 mod futures_utility;


### PR DESCRIPTION
Added an examples folder and created a runtime which sends and receives data with a linux raw socket as the first example.

It requires some iptables magic to prevent the kernel getting in the way, as by default the kernel will try and handle packets even if there is a raw socket listening for them. The command `iptables -t raw -A PREROUTING -p tcp -j DROP` can be used to stop the kernel handling ALL TCP TRAFFIC until reboot, and allow the catnip stack to do it instead. This should only be done inside a VM. Someone who knows more about `iptables` than me can probably develop a more precise rule which matches known port numbers or IP addresses, to remove the VM requirement.