### PR TITLE
Bad Fast Retransmission on TCP

### DIFF
--- a/src/protocols/tcp/established/background/retransmitter.rs
+++ b/src/protocols/tcp/established/background/retransmitter.rs
@@ -27,7 +27,10 @@ pub async fn retransmit<RT: Runtime>(
     let seq_no = cb.sender.base_seq_no.get();
     let segment = match unacked_queue.front_mut() {
         Some(s) => s,
-        None => panic!("Retransmission timer set with empty acknowledge queue"),
+        None => {
+            warn!("Retransmission with empty unacknowledged queue");
+            return Ok(());
+        },
     };
 
     // TODO: Repacketization

--- a/src/protocols/tcp/established/background/retransmitter.rs
+++ b/src/protocols/tcp/established/background/retransmitter.rs
@@ -17,8 +17,9 @@ pub enum RetransmitCause {
 pub async fn retransmit<RT: Runtime>(
     cause: RetransmitCause,
     cb: &Rc<ControlBlock<RT>>,
-    ) -> Result<(), Fail> {
+) -> Result<(), Fail> {
 
+    // Pop unack'ed segment.
     let mut unacked_queue = cb.sender.unacked_queue.borrow_mut();
     let segment = match unacked_queue.front_mut() {
         Some(s) => s,
@@ -56,6 +57,7 @@ pub async fn retransmit<RT: Runtime>(
 
 pub async fn retransmitter<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
+        // Pin future for timeout retransmission.
         let (rtx_deadline, rtx_deadline_changed) = cb.sender.retransmit_deadline.watch();
         futures::pin_mut!(rtx_deadline_changed);
         let rtx_future = match rtx_deadline {


### PR DESCRIPTION
Description
========

In this Pull Request I fix the following issues:

- **[Don't panic on Empty Unacknowledged Queue](b892a957bc08b5f5c3567ccb435e93d51d54754b)**: we may have a situation where the acknowledged was received, but the retransmission co-routiner was already scheduled to be executed.
- **[Pin Future for Fast Retransmission](1b3b29f20b80fb5a89896bf3f731e978ab63ed47)**: if fast retransmission flag has not changed, we should tag the co-routine as pending (before we would scheduled it anyways).

In additional, I also introduce the following enhancements on existing code:
- **[Faster Retransmission Logic](f2cdbb2104c22f44e4e50875af5cf5d0479e1771)**: re-organized retransmission logic to make it faster.
- **[Improving Code Style](e5f716d57d04307a3f57c5e44a5db7cdd063aa48)**: improved coding style and added some comments.