### PR TITLE
Increasing Retransmit Timeout

### DIFF
--- a/src/protocols/tcp/established/state/sender.rs
+++ b/src/protocols/tcp/established/state/sender.rs
@@ -151,7 +151,7 @@ impl<RT: Runtime> Sender<RT> {
                 self.unacked_queue.borrow_mut().push_back(unacked_segment);
                 if self.retransmit_deadline.get().is_none() {
                     let rto = self.rto.borrow().estimate();
-                    self.retransmit_deadline.set(Some(cb.rt.now() + rto));
+                    self.retransmit_deadline.set(Some(cb.rt.now() + 2 * rto));
                 }
                 return Ok(());
             }


### PR DESCRIPTION
Description
========

In this Pull Request we increase the timeout for retransmitting data.

Previously we were retransmitting too frequently and thus hurting performance.