### PR TITLE
Bad Connection Termination

### DIFF
--- a/src/protocols/tcp/established/state/mod.rs
+++ b/src/protocols/tcp/established/state/mod.rs
@@ -6,7 +6,10 @@ pub mod receiver;
 mod rto;
 pub mod sender;
 
-use self::{receiver::Receiver, sender::Sender};
+use self::{
+    receiver::{Receiver, ReceiverState},
+    sender::Sender,
+};
 use crate::{
     fail::Fail,
     protocols::{
@@ -76,9 +79,11 @@ impl<RT: Runtime> ControlBlock<RT> {
 
         // Check if we have acknowledged all bytes that we have received. If not, piggy back an ACK
         // on this message.
-        if let Some(ack_seq_no) = self.receiver.current_ack() {
-            header.ack_num = ack_seq_no;
-            header.ack = true;
+        if self.receiver.state.get() != ReceiverState::AckdFin {
+            if let Some(ack_seq_no) = self.receiver.current_ack() {
+                header.ack_num = ack_seq_no;
+                header.ack = true;
+            }
         }
         header
     }


### PR DESCRIPTION
Description
=========

Our piggybacking logic was getting triggered whenever there was some acknowledge sequence number, differed from the received sequence number. While this is fine when transmitting data, when terminating the connection, we should not piggyback, due to the four-handshake protocol.