### PR TITLE
[`tcp`] Adding `send_ack()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  pull_request:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
   workflow_dispatch:
     branches:
       - bugfix-*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,6 @@ on:
       - dev
       - unstable
       - master
-  pull_request:
-    branches:
-      - bugfix-*
-      - enhancement-*
-      - feature-*
-      - workaround-*
-      - dev
-      - unstable
-      - master
   workflow_dispatch:
     branches:
       - bugfix-*

--- a/src/protocols/tcp/established/background/closer.rs
+++ b/src/protocols/tcp/established/background/closer.rs
@@ -11,6 +11,15 @@ use ::std::rc::Rc;
 
 //==============================================================================
 
+// ToDo: Eliminate this function as it is extremely inefficient.  The FIN flag should be set on the last data packet
+// sent to our peer, not sent as a separate packet.  Conceptually, and in sequence number terms, the FIN comes after
+// the last byte of data we send to our peer on this connection.  The code that sends that last unsent data knows it is
+// doing that (we should have a flag in the Control Block indicating that the user has called close()), and can simply
+// set the FIN flag on that last data packet.  And if there is no outstanding unsent data still to send when the user
+// calls close, we can immediately send a FIN (the send_ack routine should handle this).  And since the sending of this
+// FIN can be handled by the regular send mechanism, it will also set the retransmission timer appropriately so we
+// don't need to worry about the ToDo below.  There is no point to having this function at all (it also looks buggy).
+//
 async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
         let (st, st_changed) = cb.get_state();
@@ -43,6 +52,13 @@ async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fai
 
 //==============================================================================
 
+// ToDo: Eliminate this function as it is simply crazy time.  As currently implemented, it is waiting for our state
+// to become one of three non-existant states (in the TCP spec at least).  Then it is waiting for ourselves to
+// acknowledge receipt of all the data we've received from our peer, just so we can acknowledge receipt of a FIN from
+// our peer.  If we wanted to fix this function, there is no need to wait for another part of ourselves to send an ACK,
+// as we could simply ACK the remaining data and the FIN together in a single packet.  But there is no need for this
+// function at all, as we can simply send the appropriate ACK for the FIN when we receive it.
+//
 async fn active_ack_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
         let (st, st_changed) = cb.get_state();
@@ -80,6 +96,15 @@ async fn active_ack_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail
 
 //==============================================================================
 
+// ToDo: Figure out what this function is supposed to be doing, and either fix it or elminate the need for it.
+// Right now this function is waiting for our state to become the (non-existant in the spec) TimeWait2 state,
+// and aborts the connection when that happens.  Which of course the code that sets our state to the TimeWait2 state
+// could simply do itself.
+//
+// The ToDo line below hints at something that needs to be done somewhere, however.  And that is to have a 2 MSL timer
+// keeping our five tuple out of action for twice the maximum segment lifetime.  It appears nothing currently does that.
+//
+
 /// Awaits until connection terminates by our four-way handshake.
 async fn active_wait_2msl<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
@@ -97,6 +122,8 @@ async fn active_wait_2msl<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fa
 
 //==============================================================================
 
+// ToDo: Eliminate this function for basically the same reasons that we should eliminate active_ack_fin above.
+//
 async fn passive_close<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
         let (st, st_changed) = cb.get_state();
@@ -128,6 +155,9 @@ async fn passive_close<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail>
 
 //==============================================================================
 
+// ToDo: Eliminate this function for basically the same reasons that we should eliminate active_send_fin above.  It
+// also appears to be waiting for us to enter the wrong state, but maybe that's what this bogus CloseWait2 state is.
+//
 async fn passive_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
         let (st, st_changed) = cb.get_state();
@@ -157,6 +187,8 @@ async fn passive_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fa
 
 //==============================================================================
 
+// ToDo: Eliminate this function for basically the same reasons that we should eliminate active_wait_2msl above.
+//
 async fn passive_wait_fin_ack<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
         let (st, st_changed) = cb.get_state();
@@ -168,6 +200,10 @@ async fn passive_wait_fin_ack<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!
         return Err(Fail::ConnectionAborted {});
     }
 }
+
+// ToDo: Eliminate this function after eliminating all the above closer closures as separately noted above, as there
+// will no longer be any need for it.
+//
 
 /// Launches various closures having to do with connection termination. Neither `active_ack_fin`
 /// nor `active_send_fin` terminate so the only way to return is via `active_wait_2msl`.

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -19,7 +19,7 @@ use crate::{
         },
     },
 };
-use ::runtime::{fail::Fail, network::types::MacAddress, Runtime};
+use ::runtime::{fail::Fail, memory::Buffer, network::types::MacAddress, Runtime};
 use ::std::{
     cell::RefCell,
     collections::VecDeque,
@@ -142,7 +142,7 @@ pub struct ControlBlock<RT: Runtime> {
     rt: Rc<RT>,
     arp: Rc<ArpPeer<RT>>,
 
-    /// The sender end of our connection.
+    // Send-side state.  ToDo: Pull this back into the ControlBlock.
     sender: Sender<RT>,
 
     state: WatchedValue<State>,
@@ -335,6 +335,14 @@ impl<RT: Runtime> ControlBlock<RT> {
             header
         );
         let now = self.rt.now();
+
+        // ToDo: Fix the following checks to match the spec.  The first thing we need to do is check to see if the
+        // segment is acceptable sequence-wise (i.e. contains some data that fits within the receive window, or is a
+        // non-data segment with a sequence number that falls within the window).  Unacceptable segments should be ACK'd
+        // (unless they are RSTs), and then dropped.
+        //
+
+        // ToDo: Next is supposed to be the check for a RST.
         if header.syn {
             warn!("Ignoring duplicate SYN on established connection");
         }
@@ -396,6 +404,7 @@ impl<RT: Runtime> ControlBlock<RT> {
     }
 
     /// Fetch a TCP header filling out various values based on our current state.
+    /// ToDo: Fix the "filling out various values based on our current state" part to actually do that correctly.
     pub fn tcp_header(&self) -> TcpHeader {
         let mut header = TcpHeader::new(self.local.get_port(), self.remote.get_port());
         header.window_size = self.hdr_window_size();
@@ -411,6 +420,26 @@ impl<RT: Runtime> ControlBlock<RT> {
             }
         }
         header
+    }
+
+    /// Send an ACK to our peer, reflecting our current state.
+    pub fn send_ack(&self) {
+        let mut header: TcpHeader = self.tcp_header();
+        // TODO: remove the following once tcp_header() is fixed to always set the ACK info.
+        header.ack = true;
+        header.ack_num = self.receive_queue.recv_seq_no.get();
+
+        // TODO: Think about moving this to tcp_header() as well.
+        let (seq_num, _): (SeqNumber, _) = self.get_sent_seq_no();
+        header.seq_num = seq_num;
+
+        // TODO: If our user has called close and we've sent all our data (nothing left unsent), then set the FIN flag.
+
+        // TODO: Remove this if clause once emit() is fixed to not require the remote hardware addr (this should be
+        // left to the ARP layer and not exposed to TCP).
+        if let Some(remote_link_addr) = self.arp().try_query(self.remote.get_address()) {
+            self.emit(header, RT::Buf::empty(), remote_link_addr);
+        }
     }
 
     /// Transmit this message to our connected peer.

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -142,7 +142,7 @@ pub struct ControlBlock<RT: Runtime> {
     rt: Rc<RT>,
     arp: Rc<ArpPeer<RT>>,
 
-    // Send-side state.  ToDo: Pull this back into the ControlBlock.
+    // Send-side state.  TODO: Pull this back into the ControlBlock.
     sender: Sender<RT>,
 
     state: WatchedValue<State>,
@@ -336,13 +336,13 @@ impl<RT: Runtime> ControlBlock<RT> {
         );
         let now = self.rt.now();
 
-        // ToDo: Fix the following checks to match the spec.  The first thing we need to do is check to see if the
+        // TODO: Fix the following checks to match the spec.  The first thing we need to do is check to see if the
         // segment is acceptable sequence-wise (i.e. contains some data that fits within the receive window, or is a
         // non-data segment with a sequence number that falls within the window).  Unacceptable segments should be ACK'd
         // (unless they are RSTs), and then dropped.
         //
 
-        // ToDo: Next is supposed to be the check for a RST.
+        // TODO: Next is supposed to be the check for a RST.
         if header.syn {
             warn!("Ignoring duplicate SYN on established connection");
         }
@@ -404,7 +404,7 @@ impl<RT: Runtime> ControlBlock<RT> {
     }
 
     /// Fetch a TCP header filling out various values based on our current state.
-    /// ToDo: Fix the "filling out various values based on our current state" part to actually do that correctly.
+    /// TODO: Fix the "filling out various values based on our current state" part to actually do that correctly.
     pub fn tcp_header(&self) -> TcpHeader {
         let mut header = TcpHeader::new(self.local.get_port(), self.remote.get_port());
         header.window_size = self.hdr_window_size();

--- a/src/protocols/tcp/established/sender/congestion_ctrl/cubic.rs
+++ b/src/protocols/tcp/established/sender/congestion_ctrl/cubic.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-// ToDo: Add better explanatory comment.
+// TODO: Add better explanatory comment.
 // This (i.e. "cubic") appears to be an implementation of RFC 8312.  Note this is an informational RFC, not a standards
 // track document.  RFC 8312 documents the non-standard congestion control algorithm used in Linux.  It appears to
 // differ from the standard congestion control algorithm only on the sender side.  In particular, it uses a cubic
 // function instead of a linear window increase function.
-// ToDo: Review if we really care to support this.
+// TODO: Review if we really care to support this.
 
 use super::{
     CongestionControl, FastRetransmitRecovery, LimitedTransmit, Options,
@@ -361,7 +361,7 @@ impl<RT: Runtime> FastRetransmitRecovery<RT> for Cubic {
 
     fn on_base_seq_no_wraparound(&self) {
         // This still won't let us enter fast recovery if base_seq_no wraps to precisely 0, but there's nothing to be done in that case.
-        // ToDo: Review this.  Now that we have real sequence numbers, we probably don't need this function anymore.
+        // TODO: Review this.  Now that we have real sequence numbers, we probably don't need this function anymore.
         self.recover.set(SeqNumber::from(0));
     }
 }

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -266,7 +266,7 @@ impl<RT: Runtime> Sender<RT> {
         let new_base_seq_no = self.base_seq_no.get();
         if new_base_seq_no < base_seq_no {
             // We've wrapped around, and so we need to do some bookkeeping
-            // ToDo: Figure out what this is doing -- it's probably wrong.
+            // TODO: Figure out what this is doing -- it's probably wrong.
             self.congestion_ctrl.on_base_seq_no_wraparound();
         }
 

--- a/src/protocols/tcp/segment.rs
+++ b/src/protocols/tcp/segment.rs
@@ -458,7 +458,7 @@ impl TcpHeader {
         }
     }
 
-    // ToDo: Review the use of usize here (and everywhere in catnip, really).
+    // TODO: Review the use of usize here (and everywhere in catnip, really).
     pub fn compute_size(&self) -> usize {
         let mut size = MIN_TCP_HEADER_SIZE;
         for i in 0..self.num_options {
@@ -470,7 +470,7 @@ impl TcpHeader {
         }
 
         // Round up to the next multiple of 4 so the TCP data is always 32 bit aligned.
-        // ToDo: Review why wrapping_add is used here.
+        // TODO: Review why wrapping_add is used here.
         size.wrapping_add(3) & !0x3
     }
 

--- a/src/protocols/tcp/tests/established.rs
+++ b/src/protocols/tcp/tests/established.rs
@@ -128,7 +128,7 @@ fn recv_pure_ack(
     sender: &mut Engine<TestRuntime>,
     receiver: &mut Engine<TestRuntime>,
     window_size: u16,
-    seq_no: SeqNumber,
+    ack_num: SeqNumber,
 ) {
     trace!(
         "====> ack: {:?} -> {:?}",
@@ -148,7 +148,7 @@ fn recv_pure_ack(
             sender.rt().local_ipv4_addr(),
             receiver.rt().local_ipv4_addr(),
             window_size,
-            seq_no,
+            ack_num,
         );
         receiver.receive(bytes).unwrap();
     }

--- a/src/protocols/tcp/tests/mod.rs
+++ b/src/protocols/tcp/tests/mod.rs
@@ -46,7 +46,11 @@ pub fn check_packet_data(
 
 //=============================================================================
 
-/// Checks for a pure ACL packet.
+/// Checks for a pure ACK packet.
+/// ToDo: Perhaps rename this, as the term "pure ACK" isn't normally used to describe anything in TCP.  The original
+/// version of this function compared the header sequence number field to zero (as if it wasn't set to anything),
+/// which is incorrect (i.e. it was checking for incorrect behavior).  For an established connection, the current
+/// sequence number should always reflect the current SND.NXT (send next).
 pub fn check_packet_pure_ack(
     bytes: Bytes,
     eth2_src_addr: MacAddress,
@@ -66,7 +70,6 @@ pub fn check_packet_pure_ack(
     let (tcp_header, tcp_payload) = TcpHeader::parse(&ipv4_header, ipv4_payload, false).unwrap();
     assert_eq!(tcp_payload.len(), 0);
     assert_eq!(tcp_header.window_size, window_size);
-    assert_eq!(tcp_header.seq_num, SeqNumber::from(0));
     assert_eq!(tcp_header.ack, true);
     assert_eq!(tcp_header.ack_num, ack_num);
 }

--- a/src/protocols/tcp/tests/mod.rs
+++ b/src/protocols/tcp/tests/mod.rs
@@ -47,7 +47,7 @@ pub fn check_packet_data(
 //=============================================================================
 
 /// Checks for a pure ACK packet.
-/// ToDo: Perhaps rename this, as the term "pure ACK" isn't normally used to describe anything in TCP.  The original
+/// TODO: Perhaps rename this, as the term "pure ACK" isn't normally used to describe anything in TCP.  The original
 /// version of this function compared the header sequence number field to zero (as if it wasn't set to anything),
 /// which is incorrect (i.e. it was checking for incorrect behavior).  For an established connection, the current
 /// sequence number should always reflect the current SND.NXT (send next).


### PR DESCRIPTION
The main thing this check-in does is add a "send_ack()" routine to ControlBlock that sends an ACK to our peer.  The send_ack routine takes no arguments, as all the TCP header field information is filled in from values in the ControlBlock state.  I also modified the acknowledger to use this routine to send its ACKs.

I fixed a bug in doing so, as the acknowledger was sending all of its ACKs with zero in the sequence number field.  send_ack will set this value appropriately (i.e. to SND.NXT).  Without this fix, most other TCPs (i.e. correctly behaving ones) would reject most of our ACK packets.  We still have a bug in our receive path where we don't check incoming packets correctly, which is why we accepted these bad ACKs as okay.

I looked into changing all of the closer closures to use this new send_ack routine as well, however, all of the closer closures are currently buggy and won't be needed anymore if we fix the receive path properly.  So I just added a number of ToDo comments to closer.rs documenting some of the problems.

Finally, there was a test (check_packet_pure_ack) that was actually testing that we were doing the wrong thing with regards to setting the sequence number in the ACK packets.  So I fixed this by removing the check of the sequence number field.  Ideally, we would have a test that checks that our sequence number field is properly set to SND.NXT.