### PR TITLE
[tcp] Fix Numerous Receive Processing Problems

### DIFF
--- a/src/protocols/tcp/established/background/closer.rs
+++ b/src/protocols/tcp/established/background/closer.rs
@@ -19,7 +19,8 @@ use ::std::rc::Rc;
 // set the FIN flag on that last data packet.  And if there is no outstanding unsent data still to send when the user
 // calls close, we can immediately send a FIN (the send_ack routine should handle this).  And since the sending of this
 // FIN can be handled by the regular send mechanism, it will also set the retransmission timer appropriately so we
-// don't need to worry about the ToDo below.  There is no point to having this function at all (it also looks buggy).
+// don't need to worry about the ToDo below.  There is no point to having this function at all (it is also buggy in
+// that the segment it sends is malformed -- it is lacking an acknowledgement number).
 //
 async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {

--- a/src/protocols/tcp/established/background/closer.rs
+++ b/src/protocols/tcp/established/background/closer.rs
@@ -72,7 +72,7 @@ async fn active_ack_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail
 
         // Wait for all data to be acknowledged.
         let (ack_seq, ack_seq_changed) = cb.get_ack_seq_no();
-        let (recv_seq, _) = cb.get_recv_seq_no();
+        let recv_seq = cb.get_recv_seq_no();
         if ack_seq != recv_seq {
             ack_seq_changed.await;
             continue;
@@ -137,7 +137,7 @@ async fn passive_close<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail>
 
         // Wait for all data to be acknowledged.
         let (ack_seq, ack_seq_changed) = cb.get_ack_seq_no();
-        let (recv_seq, _) = cb.get_recv_seq_no();
+        let recv_seq = cb.get_recv_seq_no();
         if ack_seq != recv_seq {
             ack_seq_changed.await;
             continue;

--- a/src/protocols/tcp/established/background/closer.rs
+++ b/src/protocols/tcp/established/background/closer.rs
@@ -26,7 +26,7 @@ async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fai
     loop {
         let (st, st_changed) = cb.get_state();
 
-        // Wait until we receive a FIN.
+        // Wait until the user calls close.
         if st != State::ActiveClose {
             st_changed.await;
             continue;

--- a/src/protocols/tcp/established/background/closer.rs
+++ b/src/protocols/tcp/established/background/closer.rs
@@ -65,7 +65,7 @@ async fn active_ack_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail
     loop {
         let (st, st_changed) = cb.get_state();
 
-        if st != State::FinWait3 && st != State::TimeWait1 && st != State::Closing1 {
+        if st != State::FinWait3 && st != State::TimeWait && st != State::Closing {
             st_changed.await;
             continue;
         }
@@ -88,7 +88,7 @@ async fn active_ack_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail
         header.ack_num = recv_seq + SeqNumber::from(1);
         cb.emit(header, RT::Buf::empty(), remote_link_addr);
 
-        if st == State::Closing1 {
+        if st == State::Closing {
             cb.set_state(State::Closing2)
         } else {
             cb.set_state(State::TimeWait2);
@@ -150,7 +150,7 @@ async fn passive_close<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail>
         header.ack_num = recv_seq + SeqNumber::from(1);
         cb.emit(header, RT::Buf::empty(), remote_link_addr);
 
-        cb.set_state(State::CloseWait1);
+        cb.set_state(State::CloseWait);
     }
 }
 

--- a/src/protocols/tcp/established/background/closer.rs
+++ b/src/protocols/tcp/established/background/closer.rs
@@ -12,15 +12,14 @@ use ::std::rc::Rc;
 
 //==============================================================================
 
-// TODO: Eliminate this function as it is extremely inefficient.  The FIN flag should be set on the last data packet
+// ToDo: Eliminate this function as it is extremely inefficient.  The FIN flag should be set on the last data packet
 // sent to our peer, not sent as a separate packet.  Conceptually, and in sequence number terms, the FIN comes after
 // the last byte of data we send to our peer on this connection.  The code that sends that last unsent data knows it is
 // doing that (we should have a flag in the Control Block indicating that the user has called close()), and can simply
 // set the FIN flag on that last data packet.  And if there is no outstanding unsent data still to send when the user
 // calls close, we can immediately send a FIN (the send_ack routine should handle this).  And since the sending of this
 // FIN can be handled by the regular send mechanism, it will also set the retransmission timer appropriately so we
-// don't need to worry about the ToDo below.  There is no point to having this function at all (it is also buggy in
-// that the segment it sends is malformed -- it is lacking an acknowledgement number).
+// don't need to worry about the ToDo below.  There is no point to having this function at all (it also looks buggy).
 //
 async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
@@ -41,7 +40,7 @@ async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fai
             continue;
         }
 
-        // TODO: When do we retransmit this?
+        // ToDo: When do we retransmit this?
         let remote_link_addr = cb.arp().query(cb.get_remote().get_address()).await?;
         let mut header = cb.tcp_header();
         header.seq_num = sent_seq;
@@ -54,7 +53,7 @@ async fn active_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fai
 
 //==============================================================================
 
-// TODO: Eliminate this function as it is simply crazy time.  As currently implemented, it is waiting for our state
+// ToDo: Eliminate this function as it is simply crazy time.  As currently implemented, it is waiting for our state
 // to become one of three non-existant states (in the TCP spec at least).  Then it is waiting for ourselves to
 // acknowledge receipt of all the data we've received from our peer, just so we can acknowledge receipt of a FIN from
 // our peer.  This is inefficient, as the code that is acknowledging our peer's data knows that we've received the FIN,
@@ -98,7 +97,7 @@ async fn active_ack_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail
 
 //==============================================================================
 
-// TODO: Figure out what this function is supposed to be doing, and either fix it or elminate the need for it.
+// ToDo: Figure out what this function is supposed to be doing, and either fix it or elminate the need for it.
 // Right now this function is waiting for our state to become the (non-existant in the spec) TimeWait2 state,
 // and aborts the closer closures when that happens.  Is that its only purpose?
 //
@@ -116,14 +115,14 @@ async fn active_wait_2msl<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fa
             continue;
         }
 
-        // TODO: Wait for 2*MSL if active close.
+        // ToDo: Wait for 2*MSL if active close.
         return Err(Fail::new(ECONNABORTED, "connection aborted"));
     }
 }
 
 //==============================================================================
 
-// TODO: Eliminate this function for basically the same reasons that we should eliminate active_ack_fin above.
+// ToDo: Eliminate this function for basically the same reasons that we should eliminate active_ack_fin above.
 //
 async fn passive_close<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
@@ -156,7 +155,7 @@ async fn passive_close<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail>
 
 //==============================================================================
 
-// TODO: Eliminate this function for basically the same reasons that we should eliminate active_send_fin above.  It
+// ToDo: Eliminate this function for basically the same reasons that we should eliminate active_send_fin above.  It
 // also appears to be waiting for us to enter the wrong state, but maybe that's what this bogus CloseWait2 state is.
 //
 async fn passive_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
@@ -188,7 +187,7 @@ async fn passive_send_fin<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fa
 
 //==============================================================================
 
-// TODO: Eliminate this function for basically the same reasons that we should eliminate active_wait_2msl above.
+// ToDo: Eliminate this function for basically the same reasons that we should eliminate active_wait_2msl above.
 //
 async fn passive_wait_fin_ack<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
     loop {
@@ -202,7 +201,7 @@ async fn passive_wait_fin_ack<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!
     }
 }
 
-// TODO: Eliminate this function after eliminating all the above closer closures as separately noted above, as there
+// ToDo: Eliminate this function after eliminating all the above closer closures as separately noted above, as there
 // will no longer be any need for it.
 //
 

--- a/src/protocols/tcp/established/background/sender.rs
+++ b/src/protocols/tcp/established/background/sender.rs
@@ -13,8 +13,6 @@ pub async fn sender<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
         let (unsent_seq, unsent_seq_changed) = cb.get_unsent_seq_no();
         futures::pin_mut!(unsent_seq_changed);
 
-        // TODO: We don't need to watch this value since we're the only mutator.
-        // ToDo: Above comment looks wrong, the main send routine modifies it.
         let (sent_seq, sent_seq_changed) = cb.get_sent_seq_no();
         futures::pin_mut!(sent_seq_changed);
 

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -147,7 +147,7 @@ pub struct ControlBlock<RT: Runtime> {
     rt: Rc<RT>,
     arp: Rc<ArpPeer<RT>>,
 
-    // Send-side state.  TODO: Pull this back into the ControlBlock.
+    // Send-side state.  ToDo: Pull this back into the ControlBlock.
     sender: Sender<RT>,
 
     state: WatchedValue<State>,
@@ -339,13 +339,13 @@ impl<RT: Runtime> ControlBlock<RT> {
         );
         let now = self.rt.now();
 
-        // TODO: Fix the following checks to match the spec.  The first thing we need to do is check to see if the
+        // ToDo: Fix the following checks to match the spec.  The first thing we need to do is check to see if the
         // segment is acceptable sequence-wise (i.e. contains some data that fits within the receive window, or is a
         // non-data segment with a sequence number that falls within the window).  Unacceptable segments should be ACK'd
         // (unless they are RSTs), and then dropped.
         //
 
-        // TODO: Next is supposed to be the check for a RST.
+        // ToDo: Next is supposed to be the check for a RST.
         if header.syn {
             warn!("Ignoring duplicate SYN on established connection");
         }
@@ -407,14 +407,14 @@ impl<RT: Runtime> ControlBlock<RT> {
     }
 
     /// Fetch a TCP header filling out various values based on our current state.
-    /// TODO: Fix the "filling out various values based on our current state" part to actually do that correctly.
+    /// ToDo: Fix the "filling out various values based on our current state" part to actually do that correctly.
     pub fn tcp_header(&self) -> TcpHeader {
         let mut header = TcpHeader::new(self.local.get_port(), self.remote.get_port());
         header.window_size = self.hdr_window_size();
 
         // Check if we have acknowledged all bytes that we have received. If not, piggy back an ACK
         // on this message.
-        // TODO: This is a bug (or two).  Except for an active open SYN where we don't yet have a remote sequence
+        // ToDo: This is a bug (or two).  Except for an active open SYN where we don't yet have a remote sequence
         // number to acknowledge, we should *always* ACK.
         if self.state.get() != State::CloseWait2 {
             if let Some(ack_seq_no) = self.current_ack() {
@@ -422,23 +422,24 @@ impl<RT: Runtime> ControlBlock<RT> {
                 header.ack = true;
             }
         }
+
         header
     }
 
     /// Send an ACK to our peer, reflecting our current state.
     pub fn send_ack(&self) {
         let mut header: TcpHeader = self.tcp_header();
-        // TODO: remove the following once tcp_header() is fixed to always set the ACK info.
+        // ToDo: remove the following once tcp_header() is fixed to always set the ACK info.
         header.ack = true;
         header.ack_num = self.receive_queue.recv_seq_no.get();
 
-        // TODO: Think about moving this to tcp_header() as well.
+        // ToDo: Think about moving this to tcp_header() as well.
         let (seq_num, _): (SeqNumber, _) = self.get_sent_seq_no();
         header.seq_num = seq_num;
 
-        // TODO: If our user has called close and we've sent all our data (nothing left unsent), then set the FIN flag.
+        // ToDo: If our user has called close and we've sent all our data (nothing left unsent), then set the FIN flag.
 
-        // TODO: Remove this if clause once emit() is fixed to not require the remote hardware addr (this should be
+        // ToDo: Remove this if clause once emit() is fixed to not require the remote hardware addr (this should be
         // left to the ARP layer and not exposed to TCP).
         if let Some(remote_link_addr) = self.arp().try_query(self.remote.get_address()) {
             self.emit(header, RT::Buf::empty(), remote_link_addr);

--- a/src/protocols/tcp/established/mod.rs
+++ b/src/protocols/tcp/established/mod.rs
@@ -45,7 +45,7 @@ impl<RT: Runtime> EstablishedSocket<RT> {
         }
     }
 
-    pub fn receive(&self, header: &TcpHeader, data: RT::Buf) {
+    pub fn receive(&self, header: &mut TcpHeader, data: RT::Buf) {
         self.cb.receive(header, data)
     }
 

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -178,9 +178,7 @@ impl<RT: Runtime> Sender<RT> {
         // If the user is done sending (i.e. has called close on this connection), then they shouldn't be sending.
         //
         if cb.user_is_done_sending.get() {
-            return Err(Fail::Invalid {
-                details: "Connection is closing",
-            });
+            return Err(Fail::new(EINVAL, "Connection is closing"));
         }
 
         // ToDo: Review below comment for accuracy.

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -181,10 +181,10 @@ impl<RT: Runtime> Sender<RT> {
             return Err(Fail::new(EINVAL, "Connection is closing"));
         }
 
-        // ToDo: Review below comment for accuracy.
         // Our API supports send buffers up to usize (variable, depends upon architecture) in size.  While we could
-        // allow for larger send buffers, it is simpler and more practical to limit a single send to 2 GiB, which is
+        // allow for larger send buffers, it is simpler and more practical to limit a single send to 1 GiB, which is
         // also the maximum value a TCP can advertise as its receive window (with maximum window scaling).
+        // ToDo: the below check just limits a single send to 4 GiB, not 1 GiB.  Check this doesn't break anything.
         //
         // Review: Move this check up the stack (i.e. closer to the user)?
         //

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -23,6 +23,10 @@ use ::std::{
     time::{Duration, Instant},
 };
 
+// Structure of entries on our unacknowledged queue.
+// ToDo: We currently allocate these on the fly when we add a buffer to the queue.  Would be more efficient to have a
+// buffer structure that held everything we need directly, thus avoiding this extra wrapper.
+//
 pub struct UnackedSegment<RT: Runtime> {
     pub bytes: RT::Buf,
     // Set to `None` on retransmission to implement Karn's algorithm.
@@ -30,6 +34,8 @@ pub struct UnackedSegment<RT: Runtime> {
 }
 
 /// Hard limit for unsent queue.
+/// ToDo: Remove this.  We should limit the unsent queue by either having a (configurable) send buffer size (in bytes,
+/// not segments) and rejecting send requests that exceed that, or by limiting the user's send buffer allocations.
 const UNSENT_QUEUE_CUTOFF: usize = 1024;
 
 pub struct Sender<RT: Runtime> {
@@ -42,19 +48,35 @@ pub struct Sender<RT: Runtime> {
     // ... ---------------|-------------------------|----------------------| (unavailable)
     //       acknowledged        unacknowledged     ^        unsent
     //
+
+    // ToDo: Rename this.  It appears to be SND.UNA.
     base_seq_no: WatchedValue<SeqNumber>,
+
+    // RFC 793 calls this the "retransmission queue".
     unacked_queue: RefCell<VecDeque<UnackedSegment<RT>>>,
+
+    // ToDo: Rename this.  It appears to be SND.NXT.
     sent_seq_no: WatchedValue<SeqNumber>,
+
+    // This is the send buffer (user data we do not yet have window to send).
     unsent_queue: RefCell<VecDeque<RT::Buf>>,
+
+    // ToDo: Remove this.
     unsent_seq_no: WatchedValue<SeqNumber>,
 
+    // ToDo: Rename this.  It appears to be SND.WND.
     window_size: WatchedValue<u32>,
+
     // RFC 1323: Number of bits to shift advertised window, defaults to zero.
     window_scale: u8,
 
+    // Maximum Segment Size currently in use for this connection.
+    // ToDo: Revisit this once we support path MTU discovery.
     mss: usize,
 
     retransmit_deadline: WatchedValue<Option<Instant>>,
+
+    // Retransmission Timeout (RTO) calculator.
     rto: RefCell<RtoCalculator>,
 
     congestion_ctrl: Box<dyn cc::CongestionControl<RT>>,
@@ -150,57 +172,114 @@ impl<RT: Runtime> Sender<RT> {
         self.rto.borrow_mut().record_failure()
     }
 
+    // This is the main TCP send routine.
+    //
     pub fn send(&self, buf: RT::Buf, cb: &ControlBlock<RT>) -> Result<(), Fail> {
-        // Our API supports send buffers up to usize (variable, depends upon architecture) in size.
+        // If the user is done sending (i.e. has called close on this connection), then they shouldn't be sending.
         //
-        let buf_len: u32 = buf.len().try_into().map_err(|_| Fail::new(EINVAL, "buffer too large"))?;
+        if cb.user_is_done_sending.get() {
+            return Err(Fail::Invalid {
+                details: "Connection is closing",
+            });
+        }
 
-        let win_sz = self.window_size.get();
-        let base_seq = self.base_seq_no.get();
-        let sent_seq = self.sent_seq_no.get();
-        let sent_data: u32 = (sent_seq - base_seq).into();
+        // ToDo: Review below comment for accuracy.
+        // Our API supports send buffers up to usize (variable, depends upon architecture) in size.  While we could
+        // allow for larger send buffers, it is simpler and more practical to limit a single send to 2 GiB, which is
+        // also the maximum value a TCP can advertise as its receive window (with maximum window scaling).
+        //
+        // Review: Move this check up the stack (i.e. closer to the user)?
+        //
+        let mut buf_len: u32 = buf.len().try_into().map_err(|_| Fail::new(EINVAL, "buffer too large"))?;
 
-        // Fast path: Try to send the data immediately.
-        let in_flight_after_send = sent_data + buf_len;
+        // ToDo: What we should do here:
+        //
+        // Conceptually, we should take the provided buffer and add it to the unsent queue.  Then calculate the amount
+        // of data we're currently allowed to send (based off of the receiver's advertised window, our congestion
+        // control algorithm, silly window syndrome avoidance algorithm, etc).  Finally, enter a loop where we compose
+        // maximum sized segments from the data on the unsent queue and send them, saving a (conceptual) copy of the
+        // sent data on the unacknowledged queue, until we run out of either window space or unsent data.
+        //
+        // Note that there are several shortcuts we can make to this conceptual approach to speed the common case.
+        // Note also that this conceptual send code is almost identical to what our "background send" algorithm should
+        // be doing, so we should just have a single function that we call from both places.
+        //
+        // The current code below just tries to send the provided buffer immediately (if allowed), otherwise it places
+        // it on the unsent queue and that's it.
+        //
 
-        // Before we get cwnd for the check, we prompt it to shrink it if the connection has been idle
-        self.congestion_ctrl.on_cwnd_check_before_send();
-        let cwnd = self.congestion_ctrl.get_cwnd();
-        // The limited transmit algorithm can increase the effective size of cwnd by up to 2MSS
-        let effective_cwnd = cwnd + self.congestion_ctrl.get_limited_transmit_cwnd_increase();
+        // Check for unsent data.
+        if self.unsent_queue.borrow().is_empty() {
 
-        if self.unsent_queue.borrow().len() == 0 {
+            // No unsent data queued up, so we can try to send this new buffer immediately.
+
+            // Calculate amount of data in flight (SND.NXT - SND.UNA).
+            let base_seq = self.base_seq_no.get();
+            let sent_seq = self.sent_seq_no.get();
+            let sent_data: u32 = (sent_seq - base_seq).into();
+
+            // ToDo: What limits buffer len to MSS?
+            let in_flight_after_send = sent_data + buf_len;
+
+            // Before we get cwnd for the check, we prompt it to shrink it if the connection has been idle.
+            self.congestion_ctrl.on_cwnd_check_before_send();
+            let cwnd = self.congestion_ctrl.get_cwnd();
+
+            // The limited transmit algorithm can increase the effective size of cwnd by up to 2MSS.
+            let effective_cwnd = cwnd + self.congestion_ctrl.get_limited_transmit_cwnd_increase();
+
+            let win_sz = self.window_size.get();
+
             if win_sz > 0
                 && win_sz >= in_flight_after_send
                 && effective_cwnd >= in_flight_after_send
             {
                 if let Some(remote_link_addr) = cb.arp().try_query(cb.get_remote().get_address()) {
-                    // This hook is primarily intended to record the last time we sent data, so we can later tell if the connection has been idle
-
+                    // This hook is primarily intended to record the last time we sent data, so we can later tell if
+                    // the connection has been idle.
                     let rto: Duration = self.current_rto();
                     self.congestion_ctrl.on_send(rto, sent_data);
 
+                    // Prepare the segment and send it.
                     let mut header = cb.tcp_header();
                     header.seq_num = sent_seq;
+                    if buf_len == 0 {
+                        // This buffer is the end-of-send marker.
+                        debug_assert_eq!(cb.user_is_done_sending.get(), true);
+                        // Set FIN and adjust sequence number consumption accordingly.
+                        header.fin = true;
+                        buf_len = 1;
+                    }
                     cb.emit(header, buf.clone(), remote_link_addr);
 
-                    self.unsent_seq_no.modify(|s| s + SeqNumber::from(buf_len));
+                    // Update SND.NXT.
                     self.sent_seq_no.modify(|s| s + SeqNumber::from(buf_len));
+
+                    // ToDo: We don't need to track this.
+                    self.unsent_seq_no.modify(|s| s + SeqNumber::from(buf_len));
+
+                    // Put the segment we just sent on the retransmission queue.
                     let unacked_segment = UnackedSegment {
                         bytes: buf,
                         initial_tx: Some(cb.rt().now()),
                     };
                     self.unacked_queue.borrow_mut().push_back(unacked_segment);
+
+                    // Start the retransmission timer if it isn't already running.
                     if self.retransmit_deadline.get().is_none() {
                         let rto = self.rto.borrow().estimate();
                         self.retransmit_deadline.set(Some(cb.rt().now() + rto));
                     }
+
                     return Ok(());
+                } else {
+                    warn!("no ARP cache entry for send");
                 }
             }
         }
 
         // Too fast.
+        // ToDo: We need to fix this the correct way: limit our send buffer size to the amount we're willing to buffer.
         if self.unsent_queue.borrow().len() > UNSENT_QUEUE_CUTOFF {
             return Err(Fail::new(EBUSY, "too many packets to send"));
         }
@@ -233,6 +312,7 @@ impl<RT: Runtime> Sender<RT> {
             return Err(Fail::new(EBADMSG, "ACK is outside of send window"));
         }
 
+        // Inform congestion control about this ACK.
         let rto: Duration = self.current_rto();
         self.congestion_ctrl
             .on_ack_received(rto, base_seq_no, sent_seq_no, seg_ack);
@@ -251,6 +331,7 @@ impl<RT: Runtime> Sender<RT> {
             self.retransmit_deadline.set(Some(deadline));
         }
 
+        // Remove now acknowledged data from the unacked queue and advance SND.UNA.
         // TODO: Do acks need to be on segment boundaries? How does this interact with repacketization?
         // Answer: No, ACKs need not be on segment boundaries.  We need to handle this properly.
         let mut bytes_remaining = bytes_acknowledged as usize;

--- a/src/protocols/tcp/peer.rs
+++ b/src/protocols/tcp/peer.rs
@@ -354,7 +354,7 @@ impl<RT: Runtime> Inner<RT> {
 
     fn receive(&mut self, ip_hdr: &Ipv4Header, buf: RT::Buf) -> Result<(), Fail> {
         let tcp_options = self.rt.tcp_options();
-        let (tcp_hdr, data) = TcpHeader::parse(ip_hdr, buf, tcp_options.get_rx_checksum_offload())?;
+        let (mut tcp_hdr, data) = TcpHeader::parse(ip_hdr, buf, tcp_options.get_rx_checksum_offload())?;
         debug!("TCP received {:?}", tcp_hdr);
         let local = Ipv4Endpoint::new(ip_hdr.get_dest_addr(), tcp_hdr.dst_port);
         let remote = Ipv4Endpoint::new(ip_hdr.get_src_addr(), tcp_hdr.src_port);
@@ -369,7 +369,7 @@ impl<RT: Runtime> Inner<RT> {
 
         if let Some(s) = self.established.get(&key) {
             debug!("Routing to established connection: {:?}", key);
-            s.receive(&tcp_hdr, data);
+            s.receive(&mut tcp_hdr, data);
             return Ok(());
         }
         if let Some(s) = self.connecting.get_mut(&key) {

--- a/src/protocols/tcp/sequence_number.rs
+++ b/src/protocols/tcp/sequence_number.rs
@@ -104,6 +104,8 @@ impl std::cmp::PartialOrd for SeqNumber {
 
 // Note that we specifically don't define std::cmp:Ord for sequence numbers, as there is no total order for them.
 // There is no max or min value, and if you have more than two of them, they can't be sorted into an unique order.
+
+// Unit tests for SeqNumber type.
 #[cfg(test)]
 mod tests {
     use super::SeqNumber;

--- a/src/protocols/tcp/tests/mod.rs
+++ b/src/protocols/tcp/tests/mod.rs
@@ -50,14 +50,14 @@ pub fn check_packet_data(
 /// ToDo: Perhaps rename this, as the term "pure ACK" isn't normally used to describe anything in TCP.  The original
 /// version of this function compared the header sequence number field to zero (as if it wasn't set to anything),
 /// which is incorrect (i.e. it was checking for incorrect behavior).  For an established connection, the current
-/// sequence number should always reflect the current SND.NXT (send next).
+/// sequence number should always reflect the current SND.NXT (send next).  The original version of this function also
+/// checked the window size (which can't be predicted accurately in some test scenarios), this version no longer does.
 pub fn check_packet_pure_ack(
     bytes: Bytes,
     eth2_src_addr: MacAddress,
     eth2_dst_addr: MacAddress,
     ipv4_src_addr: Ipv4Addr,
     ipv4_dst_addr: Ipv4Addr,
-    window_size: u16,
     ack_num: SeqNumber,
 ) {
     let (eth2_header, eth2_payload) = Ethernet2Header::parse(bytes).unwrap();
@@ -69,7 +69,6 @@ pub fn check_packet_pure_ack(
     assert_eq!(ipv4_header.get_dest_addr(), ipv4_dst_addr);
     let (tcp_header, tcp_payload) = TcpHeader::parse(&ipv4_header, ipv4_payload, false).unwrap();
     assert_eq!(tcp_payload.len(), 0);
-    assert_eq!(tcp_header.window_size, window_size);
     assert_eq!(tcp_header.ack, true);
     assert_eq!(tcp_header.ack_num, ack_num);
 }

--- a/src/protocols/tcp/tests/mod.rs
+++ b/src/protocols/tcp/tests/mod.rs
@@ -47,7 +47,7 @@ pub fn check_packet_data(
 //=============================================================================
 
 /// Checks for a pure ACK packet.
-/// TODO: Perhaps rename this, as the term "pure ACK" isn't normally used to describe anything in TCP.  The original
+/// ToDo: Perhaps rename this, as the term "pure ACK" isn't normally used to describe anything in TCP.  The original
 /// version of this function compared the header sequence number field to zero (as if it wasn't set to anything),
 /// which is incorrect (i.e. it was checking for incorrect behavior).  For an established connection, the current
 /// sequence number should always reflect the current SND.NXT (send next).

--- a/src/test_helpers/runtime.rs
+++ b/src/test_helpers/runtime.rs
@@ -105,7 +105,7 @@ impl TestRuntime {
     }
 
     pub fn pop_frame(&self) -> Bytes {
-        self.inner.borrow_mut().outgoing.pop_front().unwrap()
+        self.inner.borrow_mut().outgoing.pop_front().expect("pop_front didn't return an outgoing frame")
     }
 
     pub fn pop_frame_unchecked(&self) -> Option<Bytes> {


### PR DESCRIPTION
The main part of this PR is around fixing the TCP incoming packet processing to make all of the proper checks in the proper order.  With these changes we will now check incoming segments to ensure that they fit within the window (and will properly trim parts that don't fit in the case of segments that partially overlap the window).  We will now act properly upon receiving a RST, SYN or FIN.  We'll also make the proper state changes upon receiving an ACK for our FIN.

There are also some send-side changes around when/how to send a FIN.  A user close() call now places a zero-length buffer onto the end of unsent queue as a "marker" for the FIN.  When normal processing gets around to sending that buffer, it will set the FIN bit in the header.  This will need to be cleaned up further, although this passes all the current tests.

Finally, I added numerous "ToDo" comments to document unfinished parts and flag other issues.

Note this is just an incremental step in fixing the myriad of problems, I'm trying to keep the changes to manageable size PRs.  This will be followed by some additional PRs to finish fixing up the most glaring of the receive side problems, as well as to cleanup the send side and to remove the closer closures.

This checkin fixes the problems mentioned in Issues #103 and #101, and is a start on fixing Issues #109, #93, #84, #82, and #63. 