### PR TITLE
[tcp] Sender Naming

### DIFF
--- a/src/protocols/tcp/established/background/retransmitter.rs
+++ b/src/protocols/tcp/established/background/retransmitter.rs
@@ -44,7 +44,7 @@ async fn retransmit<RT: Runtime>(
     segment.initial_tx.take();
 
     // Prepare and send the segment.
-    let (seq_no, _) = cb.get_base_seq_no();
+    let (seq_no, _) = cb.get_send_unacked();
     let mut header = cb.tcp_header();
     header.seq_num = seq_no;
     cb.emit(header, segment.bytes.clone(), remote_link_addr);
@@ -83,8 +83,8 @@ pub async fn retransmitter<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, F
             _ = rtx_deadline_changed => continue,
             _ = rtx_fast_retransmit_changed => continue,
             _ = rtx_future => {
-                let (base_seq_no, _) = cb.get_base_seq_no();
-                cb.congestion_ctrl_on_rto(base_seq_no);
+                let (send_unacknowledged, _) = cb.get_send_unacked();
+                cb.congestion_ctrl_on_rto(send_unacknowledged);
                 retransmit(RetransmitCause::TimeOut, &cb).await?;
             },
         }

--- a/src/protocols/tcp/established/background/sender.rs
+++ b/src/protocols/tcp/established/background/sender.rs
@@ -26,7 +26,7 @@ pub async fn sender<RT: Runtime>(cb: Rc<ControlBlock<RT>>) -> Result<!, Fail> {
 
         // Okay, we know we have some unsent data past this point. Next, check to see that the
         // remote side has available window.
-        let (win_sz, win_sz_changed) = cb.get_window_size();
+        let (win_sz, win_sz_changed) = cb.get_send_window();
         futures::pin_mut!(win_sz_changed);
 
         // If we don't have any window size at all, we need to transition to PERSIST mode and

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -266,9 +266,8 @@ impl<RT: Runtime> ControlBlock<RT> {
         self.sender.get_mss()
     }
 
-    // ToDo: Rename this for clarity?  There is both a send window size and a receive window size.
-    pub fn get_window_size(&self) -> (u32, WatchFuture<u32>) {
-        self.sender.get_window_size()
+    pub fn get_send_window(&self) -> (u32, WatchFuture<u32>) {
+        self.sender.get_send_window()
     }
 
     pub fn get_send_unacked(&self) -> (SeqNumber, WatchFuture<SeqNumber>) {

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -241,8 +241,8 @@ impl<RT: Runtime> ControlBlock<RT> {
         self.sender.congestion_ctrl_on_fast_retransmit()
     }
 
-    pub fn congestion_ctrl_on_rto(&self, base_seq_no: SeqNumber) {
-        self.sender.congestion_ctrl_on_rto(base_seq_no)
+    pub fn congestion_ctrl_on_rto(&self, send_unacknowledged: SeqNumber) {
+        self.sender.congestion_ctrl_on_rto(send_unacknowledged)
     }
 
     pub fn congestion_ctrl_on_send(&self, rto: Duration, num_sent_bytes: u32) {
@@ -271,8 +271,8 @@ impl<RT: Runtime> ControlBlock<RT> {
         self.sender.get_window_size()
     }
 
-    pub fn get_base_seq_no(&self) -> (SeqNumber, WatchFuture<SeqNumber>) {
-        self.sender.get_base_seq_no()
+    pub fn get_send_unacked(&self) -> (SeqNumber, WatchFuture<SeqNumber>) {
+        self.sender.get_send_unacked()
     }
 
     pub fn get_unsent_seq_no(&self) -> (SeqNumber, WatchFuture<SeqNumber>) {
@@ -507,7 +507,7 @@ impl<RT: Runtime> ControlBlock<RT> {
         // Start by checking that the ACK acknowledges something new.
         // ToDo: Cleanup send-side variable names and removed Watched types.
         //
-        let (send_unacknowledged, _): (SeqNumber, _) = self.sender.get_base_seq_no();
+        let (send_unacknowledged, _): (SeqNumber, _) = self.sender.get_send_unacked();
         let (send_next, _): (SeqNumber, _) = self.sender.get_sent_seq_no();
 
         if send_unacknowledged < header.ack_num {

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -103,7 +103,7 @@ impl<RT: Runtime> Receiver<RT> {
     }
 
     pub fn push(&self, buf: RT::Buf) {
-        let buf_len: u32 = buf.len() as u32;
+    let buf_len: u32 = buf.len() as u32;
         self.recv_queue.borrow_mut().push_back(buf);
         self.receive_next.set(self.receive_next.get() + SeqNumber::from(buf_len as u32));
     }
@@ -399,7 +399,7 @@ impl<RT: Runtime> ControlBlock<RT> {
                     // Some of this segment's data is new.  Cut the duplicate data off of the front.
                     // If there is a SYN at the start of this segment, remove it too.
                     //
-                    let mut duplicate = u32::from(receive_next - seg_start);
+                    let mut duplicate: u32 = u32::from(receive_next - seg_start);
                     seg_start = seg_start + SeqNumber::from(duplicate);
                     seg_len -= duplicate;
                     if header.syn {
@@ -666,7 +666,7 @@ impl<RT: Runtime> ControlBlock<RT> {
     /// Fetch a TCP header filling out various values based on our current state.
     /// ToDo: Fix the "filling out various values based on our current state" part to actually do that correctly.
     pub fn tcp_header(&self) -> TcpHeader {
-        let mut header = TcpHeader::new(self.local.get_port(), self.remote.get_port());
+        let mut header: TcpHeader = TcpHeader::new(self.local.get_port(), self.remote.get_port());
         header.window_size = self.hdr_window_size();
 
         // Note that once we reach a synchronized state we always include a valid acknowledgement number.
@@ -766,8 +766,8 @@ impl<RT: Runtime> ControlBlock<RT> {
     }
 
     pub fn hdr_window_size(&self) -> u16 {
-        let window_size = self.get_receive_window_size();
-        let hdr_window_size = (window_size >> self.window_scale)
+        let window_size: u32 = self.get_receive_window_size();
+        let hdr_window_size: u16 = (window_size >> self.window_scale)
             .try_into()
             .expect("Window size overflow");
         debug!(
@@ -791,7 +791,7 @@ impl<RT: Runtime> ControlBlock<RT> {
             return Poll::Pending;
         }
 
-        let segment = self
+        let segment: RT::Buf = self
             .receiver
             .pop()
             .expect("poll_recv failed to pop data from receive queue");

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -279,12 +279,12 @@ impl<RT: Runtime> ControlBlock<RT> {
         self.sender.get_unsent_seq_no()
     }
 
-    pub fn get_sent_seq_no(&self) -> (SeqNumber, WatchFuture<SeqNumber>) {
-        self.sender.get_sent_seq_no()
+    pub fn get_send_next(&self) -> (SeqNumber, WatchFuture<SeqNumber>) {
+        self.sender.get_send_next()
     }
 
-    pub fn modify_sent_seq_no(&self, f: impl FnOnce(SeqNumber) -> SeqNumber) {
-        self.sender.modify_sent_seq_no(f)
+    pub fn modify_send_next(&self, f: impl FnOnce(SeqNumber) -> SeqNumber) {
+        self.sender.modify_send_next(f)
     }
 
     pub fn get_retransmit_deadline(&self) -> (Option<Instant>, WatchFuture<Option<Instant>>) {
@@ -508,7 +508,7 @@ impl<RT: Runtime> ControlBlock<RT> {
         // ToDo: Cleanup send-side variable names and removed Watched types.
         //
         let (send_unacknowledged, _): (SeqNumber, _) = self.sender.get_send_unacked();
-        let (send_next, _): (SeqNumber, _) = self.sender.get_sent_seq_no();
+        let (send_next, _): (SeqNumber, _) = self.sender.get_send_next();
 
         if send_unacknowledged < header.ack_num {
             if header.ack_num <= send_next {
@@ -682,7 +682,7 @@ impl<RT: Runtime> ControlBlock<RT> {
         let mut header: TcpHeader = self.tcp_header();
 
         // ToDo: Think about moving this to tcp_header() as well.
-        let (seq_num, _): (SeqNumber, _) = self.get_sent_seq_no();
+        let (seq_num, _): (SeqNumber, _) = self.get_send_next();
         header.seq_num = seq_num;
 
         // ToDo: Remove this if clause once emit() is fixed to not require the remote hardware addr (this should be

--- a/src/protocols/tcp/established/sender/congestion_ctrl/cubic.rs
+++ b/src/protocols/tcp/established/sender/congestion_ctrl/cubic.rs
@@ -7,6 +7,7 @@
 // differ from the standard congestion control algorithm only on the sender side.  In particular, it uses a cubic
 // function instead of a linear window increase function.
 // TODO: Review if we really care to support this.
+// ToDo: Review if fast retransmit should be mixed in with congestion control or not.
 
 use super::{
     CongestionControl, FastRetransmitRecovery, LimitedTransmit, Options,
@@ -28,26 +29,26 @@ use ::std::{
 #[derive(Debug)]
 pub struct Cubic {
     pub mss: u32, // Just for convenience, otherwise we have `as u32` or `.try_into().unwrap()` scattered everywhere...
-    // Slow Start / Congestion Avoidance State
-    pub ca_start: Cell<Instant>, // The time we started the current congestion avoidance
-    pub cwnd: WatchedValue<u32>, // Congestion window: Maximum number of bytes that may be in flight ot prevent congestion
-    pub fast_convergence: bool, // Should we employ the fast convergence algorithm (Only recommended if there are multiple CUBIC streams on the same network, in which case we'll cede capacity to new ones faster)
-    pub initial_cwnd: u32, // The initial value of cwnd, which gets used if the connection ever resets
-    pub last_send_time: Cell<Instant>, // The moment at which we last sent data
-    pub last_congestion_was_rto: Cell<bool>, // A flag for whether the last congestion event was detected by RTO
-    pub retransmitted_packets_in_flight: Cell<u32>, // A flag for if there is currently a retransmitted packet in flight
-    pub rtt_at_last_send: Cell<Duration>,           // The RTT at the moment we last sent data
-    pub ssthresh: Cell<u32>, // The size of cwnd at which we will change from using slow start to congestion avoidance
-    pub w_max: Cell<u32>,    // The size of cwnd before the previous congestion event
+    // Slow Start / Congestion Avoidance State.
+    pub ca_start: Cell<Instant>, // The time we started the current congestion avoidance.
+    pub cwnd: WatchedValue<u32>, // Congestion window: Max number of bytes that may be in flight ot prevent congestion.
+    pub fast_convergence: bool, // Should we employ the fast convergence algorithm (Only recommended if there are multiple CUBIC streams on the same network, in which case we'll cede capacity to new ones faster).
+    pub initial_cwnd: u32, // The initial value of cwnd, which gets used if the connection ever resets.
+    pub last_send_time: Cell<Instant>, // The moment at which we last sent data.
+    pub last_congestion_was_rto: Cell<bool>, // A flag for whether the last congestion event was detected by RTO.
+    pub retransmitted_packets_in_flight: Cell<u32>, // A flag for if there is currently a retransmitted packet in flight.
+    pub rtt_at_last_send: Cell<Duration>, // The RTT at the moment we last sent data.
+    pub ssthresh: Cell<u32>, // The size of cwnd at which we will change from using slow start to congestion avoidance.
+    pub w_max: Cell<u32>,    // The size of cwnd before the previous congestion event.
 
     // Fast Recovery / Fast Retransmit State
-    pub duplicate_ack_count: Cell<u32>, // The number of consecutive duplicate ACKs we've received
-    pub fast_retransmit_now: WatchedValue<bool>, // Flag to cause the retransmitter to retransmit a segment now
-    pub in_fast_recovery: Cell<bool>, // Are we currently in the `fast recovery` algorithm
-    pub prev_ack_seq_no: Cell<SeqNumber>, // The previous highest ACK sequence number
-    pub recover: Cell<SeqNumber>, // If we receive dup ACKs with sequence numbers greater than this we'll attempt fast recovery
+    pub duplicate_ack_count: Cell<u32>, // The number of consecutive duplicate ACKs we've received.
+    pub fast_retransmit_now: WatchedValue<bool>, // Flag to cause the retransmitter to retransmit a segment now.
+    pub in_fast_recovery: Cell<bool>, // Are we currently in the `fast recovery` algorithm.
+    pub prev_ack_seq_no: Cell<SeqNumber>, // The previous highest ACK sequence number.
+    pub recover: Cell<SeqNumber>, // If we receive dup ACKs with sequence numbers greater than this we'll attempt fast recovery.
 
-    pub limited_transmit_cwnd_increase: WatchedValue<u32>, // The amount by which cwnd should be increased due to the limited transit algorithm
+    pub limited_transmit_cwnd_increase: WatchedValue<u32>, // The amount by which cwnd should be increased due to the limited transit algorithm.
 }
 
 impl<RT: Runtime> CongestionControl<RT> for Cubic {
@@ -57,7 +58,7 @@ impl<RT: Runtime> CongestionControl<RT> for Cubic {
         options: Option<Options>,
     ) -> Box<dyn CongestionControl<RT>> {
         let mss: u32 = mss.try_into().unwrap();
-        // The initial value of cwnd is set according to RFC5681, section 3.1, page 7
+        // The initial value of cwnd is set according to RFC5681, section 3.1, page 7.
         let initial_cwnd = match mss {
             0..=1095 => 4 * mss,
             1096..=2190 => 3 * mss,
@@ -70,21 +71,21 @@ impl<RT: Runtime> CongestionControl<RT> for Cubic {
         Box::new(Self {
             mss,
             // Slow Start / Congestion Avoidance State
-            ca_start: Cell::new(Instant::now()), // record the start time of the congestion avoidance period
+            ca_start: Cell::new(Instant::now()), // Record the start time of the congestion avoidance period.
             cwnd: WatchedValue::new(initial_cwnd),
             fast_convergence,
             initial_cwnd,
             last_send_time: Cell::new(Instant::now()),
             retransmitted_packets_in_flight: Cell::new(0),
-            rtt_at_last_send: Cell::new(Duration::new(1, 0)), // The default RTT is 1 sec
-            ssthresh: Cell::new(u32::MAX), // According to RFC5681 ssthresh should be initialised 'arbitrarily high'
-            w_max: Cell::new(0), // Because ssthresh is u32::MAX, this will be set appropriately during the 1st congestion event
+            rtt_at_last_send: Cell::new(Duration::new(1, 0)), // The default RTT is 1 sec.
+            ssthresh: Cell::new(u32::MAX), // According to RFC5681 ssthresh should be initialised 'arbitrarily high'.
+            w_max: Cell::new(0), // Because ssthresh is u32::MAX, this will be set appropriately during the 1st congestion event.
             last_congestion_was_rto: Cell::new(false),
 
             in_fast_recovery: Cell::new(false),
             fast_retransmit_now: WatchedValue::new(false),
-            recover: Cell::new(seq_no), // Recover set to initial send sequence number according to RFC6582
-            prev_ack_seq_no: Cell::new(seq_no), // RFC6582 doesn't specify the initial value, but this seems sensible
+            recover: Cell::new(seq_no), // Recover set to initial send sequence number according to RFC6582.
+            prev_ack_seq_no: Cell::new(seq_no), // RFC6582 doesn't specify the initial value, but this seems sensible.
             duplicate_ack_count: Cell::new(0),
 
             limited_transmit_cwnd_increase: WatchedValue::new(0),
@@ -93,7 +94,7 @@ impl<RT: Runtime> CongestionControl<RT> for Cubic {
 }
 
 impl Cubic {
-    // Cubic const parameters
+    // Cubic const parameters.
     const C: f32 = 0.4;
     const BETA_CUBIC: f32 = 0.7;
 
@@ -101,7 +102,7 @@ impl Cubic {
 
     fn fast_convergence(&self) {
         // The fast convergence algorithm assumes that w_max and cwnd are stored in units of mss, so we do this
-        // integer division to prevent it being applied too often
+        // integer division to prevent it being applied too often.
         let cwnd = self.cwnd.get();
 
         if (cwnd / self.mss) < self.w_max.get() / self.mss {
@@ -136,7 +137,7 @@ impl Cubic {
         if duplicate_ack_count == Self::DUP_ACK_THRESHOLD
             && (ack_covers_recover || retransmitted_packet_dropped_heuristic)
         {
-            // Check against recover specified in RFC6582
+            // Check against recover specified in RFC6582.
             self.in_fast_recovery.set(true);
             self.recover.set(sent_seq_no);
             let reduced_cwnd = (cwnd as f32 * Self::BETA_CUBIC) as u32;
@@ -158,21 +159,21 @@ impl Cubic {
 
     fn on_ack_received_fast_recovery(
         &self,
-        base_seq_no: SeqNumber,
+        send_unacked: SeqNumber,
         sent_seq_no: SeqNumber,
         ack_seq_no: SeqNumber,
     ) {
-        let bytes_outstanding: u32 = (sent_seq_no - base_seq_no).into();
-        let bytes_acknowledged: u32 = (ack_seq_no - base_seq_no).into();
+        let bytes_outstanding: u32 = (sent_seq_no - send_unacked).into();
+        let bytes_acknowledged: u32 = (ack_seq_no - send_unacked).into();
         let mss = self.mss;
 
         if ack_seq_no > self.recover.get() {
-            // Full acknowledgement
+            // Full acknowledgement.
             self.cwnd
                 .set(min(self.ssthresh.get(), max(bytes_outstanding, mss) + mss));
-            // Record the time we go back into congestion avoidance
+            // Record the time we go back into congestion avoidance.
             self.ca_start.set(Instant::now());
-            // Record that we didn't enter CA from a timeout
+            // Record that we didn't enter CA from a timeout.
             self.last_congestion_was_rto.set(false);
             self.in_fast_recovery.set(false);
         } else {
@@ -183,14 +184,14 @@ impl Cubic {
             } else {
                 self.cwnd.modify(|c| c - bytes_acknowledged);
             }
-            // We stay in fast recovery mode here because we haven't acknowledged all data up to `recovery`
+            // We stay in fast recovery mode here because we haven't acknowledged all data up to `recovery`.
             // Thus, we don't reset ca_start here either.
         }
     }
 
     fn k(&self, w_max: f32) -> f32 {
         // While we store w_max in terms of bytes, we have pre-normalised it to units of MSS
-        // for compatibility with RFC8312
+        // for compatibility with RFC8312.
         if self.last_congestion_was_rto.get() {
             0.0
         } else {
@@ -200,28 +201,28 @@ impl Cubic {
 
     fn w_cubic(&self, w_max: f32, t: f32, k: f32) -> f32 {
         // While we store w_max in terms of bytes, we have pre-normalised it to units of MSS
-        // for compatibility with RFC8312
+        // for compatibility with RFC8312.
         (Self::C) * (t - k).powi(3) + w_max
     }
 
     fn w_est(&self, w_max: f32, t: f32, rtt: f32) -> f32 {
         // While we store w_max in terms of bytes, we have pre-normalised it to units of MSS
-        // for compatibility with RFC8312
+        // for compatibility with RFC8312.
         let bc = Self::BETA_CUBIC;
         w_max * bc + ((3. * (1. - bc) / (1. + bc)) * t / rtt)
     }
 
-    fn on_ack_received_ss_ca(&self, rto: Duration, base_seq_no: SeqNumber, ack_seq_no: SeqNumber) {
-        let bytes_acknowledged: u32 = (ack_seq_no - base_seq_no).into();
+    fn on_ack_received_ss_ca(&self, rto: Duration, send_unacked: SeqNumber, ack_seq_no: SeqNumber) {
+        let bytes_acknowledged: u32 = (ack_seq_no - send_unacked).into();
         let mss = self.mss;
         let cwnd = self.cwnd.get();
         let ssthresh = self.ssthresh.get();
 
         if cwnd < ssthresh {
-            // Slow start
+            // Slow start.
             self.cwnd.modify(|c| c + min(bytes_acknowledged, mss));
         } else {
-            // Congestion avoidance
+            // Congestion avoidance.
             let t = self.ca_start.get().elapsed().as_secs_f32();
             let rtt = rto.as_secs_f32();
             let mss_f32 = mss as f32;
@@ -229,11 +230,11 @@ impl Cubic {
             let k = self.k(normalised_w_max);
             let w_est = self.w_est(normalised_w_max, t, rtt);
             if self.w_cubic(normalised_w_max, t, k) < w_est {
-                // w_est return units of MSS which we multiply back up to get bytes
+                // w_est return units of MSS which we multiply back up to get bytes.
                 self.cwnd.set((w_est * mss_f32) as u32);
             } else {
                 let cwnd_f32 = cwnd as f32;
-                // Again, do everything in terms of units of MSS
+                // Again, do everything in terms of units of MSS.
                 let normalised_cwnd = cwnd_f32 / mss_f32;
                 let cwnd_inc = ((self.w_cubic(normalised_w_max, t + rtt, k) - normalised_cwnd)
                     / normalised_cwnd)
@@ -261,17 +262,17 @@ impl Cubic {
                 .set(max((cwnd as f32 * Self::BETA_CUBIC) as u32, 2 * self.mss));
         }
 
-        // Used to decide whether to shrink ssthresh on rto
-        // We're just about to retransmit a packet, so increment the counter
+        // Used to decide whether to shrink ssthresh on rto.
+        // We're just about to retransmit a packet, so increment the counter.
         self.retransmitted_packets_in_flight.set(rpif + 1);
 
-        // Used to decide whether to set K to 0 for w_cubic
+        // Used to decide whether to set K to 0 for w_cubic.
         self.last_congestion_was_rto.set(true);
     }
 
-    fn on_rto_fast_recovery(&self, base_seq_no: SeqNumber) {
+    fn on_rto_fast_recovery(&self, send_unacked: SeqNumber) {
         // Exit fast recovery/retransmit
-        self.recover.set(base_seq_no);
+        self.recover.set(send_unacked);
         self.in_fast_recovery.set(false);
     }
 }
@@ -307,11 +308,11 @@ impl<RT: Runtime> SlowStartCongestionAvoidance<RT> for Cubic {
     fn on_ack_received(
         &self,
         rto: Duration,
-        base_seq_no: SeqNumber,
+        send_unacked: SeqNumber,
         sent_seq_no: SeqNumber,
         ack_seq_no: SeqNumber,
     ) {
-        let bytes_acknowledged: u32 = (ack_seq_no - base_seq_no).into();
+        let bytes_acknowledged: u32 = (ack_seq_no - send_unacked).into();
         if bytes_acknowledged == 0 {
             // ACK is a duplicate
             self.on_dup_ack_received(sent_seq_no, ack_seq_no);
@@ -323,20 +324,20 @@ impl<RT: Runtime> SlowStartCongestionAvoidance<RT> for Cubic {
             self.duplicate_ack_count.set(0);
 
             if self.in_fast_recovery.get() {
-                // Fast Recovery response to new data
-                self.on_ack_received_fast_recovery(base_seq_no, sent_seq_no, ack_seq_no);
+                // Fast Recovery response to new data.
+                self.on_ack_received_fast_recovery(send_unacked, sent_seq_no, ack_seq_no);
             } else {
-                self.on_ack_received_ss_ca(rto, base_seq_no, ack_seq_no);
+                self.on_ack_received_ss_ca(rto, send_unacked, ack_seq_no);
             }
-            // Used to handle dup ACKs after timeout
+            // Used to handle dup ACKs after timeout.
             self.prev_ack_seq_no.set(ack_seq_no);
         }
     }
 
-    fn on_rto(&self, base_seq_no: SeqNumber) {
-        // Handle timeout for any of the algorithms we could currently be using
+    fn on_rto(&self, send_unacked: SeqNumber) {
+        // Handle timeout for any of the algorithms we could currently be using.
         self.on_rto_ss_ca();
-        self.on_rto_fast_recovery(base_seq_no);
+        self.on_rto_fast_recovery(send_unacked);
     }
 }
 
@@ -357,12 +358,6 @@ impl<RT: Runtime> FastRetransmitRecovery<RT> for Cubic {
         // I suspect it doesn't matter because we only retransmit on the 3rd repeat ACK precisely...
         // I should really use some other mechanism here just because it would be nicer...
         self.fast_retransmit_now.set_without_notify(false);
-    }
-
-    fn on_base_seq_no_wraparound(&self) {
-        // This still won't let us enter fast recovery if base_seq_no wraps to precisely 0, but there's nothing to be done in that case.
-        // TODO: Review this.  Now that we have real sequence numbers, we probably don't need this function anymore.
-        self.recover.set(SeqNumber::from(0));
     }
 }
 

--- a/src/protocols/tcp/established/sender/congestion_ctrl/mod.rs
+++ b/src/protocols/tcp/established/sender/congestion_ctrl/mod.rs
@@ -30,7 +30,7 @@ pub trait SlowStartCongestionAvoidance<RT: Runtime> {
         &self,
         _rto: Duration,
         _send_unacked: SeqNumber,
-        _sent_seq_no: SeqNumber,
+        _send_next: SeqNumber,
         _ack_seq_no: SeqNumber,
     ) {
     }

--- a/src/protocols/tcp/established/sender/congestion_ctrl/mod.rs
+++ b/src/protocols/tcp/established/sender/congestion_ctrl/mod.rs
@@ -23,22 +23,22 @@ pub trait SlowStartCongestionAvoidance<RT: Runtime> {
         (u32::MAX, WatchFuture::Pending)
     }
 
-    // Called immediately before the cwnd check is performed before data is sent
+    // Called immediately before the cwnd check is performed before data is sent.
     fn on_cwnd_check_before_send(&self) {}
 
     fn on_ack_received(
         &self,
         _rto: Duration,
-        _base_seq_no: SeqNumber,
+        _send_unacked: SeqNumber,
         _sent_seq_no: SeqNumber,
         _ack_seq_no: SeqNumber,
     ) {
     }
 
-    // Called immediately before retransmit after RTO
-    fn on_rto(&self, _base_seq_no: SeqNumber) {}
+    // Called immediately before retransmit after RTO.
+    fn on_rto(&self, _send_unacked: SeqNumber) {}
 
-    // Called immediately before a segment is sent for the 1st time
+    // Called immediately before a segment is sent for the 1st time.
     fn on_send(&self, _rto: Duration, _num_sent_bytes: u32) {}
 }
 
@@ -58,7 +58,6 @@ where
     }
 
     fn on_fast_retransmit(&self) {}
-    fn on_base_seq_no_wraparound(&self) {}
 }
 
 pub trait LimitedTransmit<RT: Runtime>

--- a/src/protocols/tcp/established/sender/rto.rs
+++ b/src/protocols/tcp/established/sender/rto.rs
@@ -30,7 +30,7 @@ impl RtoCalculator {
         const BETA: f64 = 0.25;
         const GRANULARITY: f64 = 0.001f64;
 
-        let rtt = FloatDuration::from(rtt).as_seconds();
+        let rtt: f64 = FloatDuration::from(rtt).as_seconds();
 
         if !self.received_sample {
             self.srtt = rtt;
@@ -41,7 +41,7 @@ impl RtoCalculator {
             self.srtt = (1.0 - ALPHA) * self.srtt + ALPHA * rtt;
         }
 
-        let rttvar_x4 = match (4.0 * self.rttvar).partial_cmp(&GRANULARITY) {
+        let rttvar_x4: f64 = match (4.0 * self.rttvar).partial_cmp(&GRANULARITY) {
             Some(cmp::Ordering::Less) => GRANULARITY,
             None => panic!("NaN rttvar: {:?}", self.rttvar),
             _ => self.rttvar,


### PR DESCRIPTION
This PR renames several send-side variables to have more meaningful names (and names that should also be more familiar to people who have read the RFCs).

Additionally, it adds explicit types to some more variable declarations.
