### PR TITLE
[tcp] Fixes for Processing of Received ACKs, Receiving Out-of-order Segments, Delayed ACKs, etc.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,11 +500,14 @@ impl<RT: Runtime> Catnip<RT> {
         let (header, payload) = Ethernet2Header::parse(bytes)?;
         debug!("Engine received {:?}", header);
         if self.rt.local_link_addr() != header.dst_addr() && !header.dst_addr().is_broadcast() {
-            return Err(Fail::new(EINVAL, "physical destination address mismatch"));
+            // ToDo: Add support for is_multicast() to MacAddress type.  Then remove following trace and restore return.
+            trace!("Need to add && !header.dst_addr().is_multicast()");
+            //return Err(Fail::new(EINVAL, "physical destination address mismatch"));
         }
         match header.ether_type() {
             EtherType2::Arp => self.arp.receive(payload),
             EtherType2::Ipv4 => self.ipv4.receive(payload),
+            EtherType2::Ipv6 => Ok(()),  // Ignore for now.
         }
     }
 

--- a/src/protocols/ethernet2/protocol.rs
+++ b/src/protocols/ethernet2/protocol.rs
@@ -11,6 +11,7 @@ use ::std::convert::TryFrom;
 pub enum EtherType2 {
     Arp = 0x806,
     Ipv4 = 0x800,
+    Ipv6 = 0x86dd,
 }
 
 impl TryFrom<u16> for EtherType2 {

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -600,10 +600,7 @@ impl<RT: Runtime> ControlBlock<RT> {
 
         // We can only process in-order data (or FIN).  Check for out-of-order segment.
         if seg_start != receive_next {
-<<<<<<< HEAD
-=======
             debug!("Received out-of-order segment");
->>>>>>> brian-wip
             // This segment is out-of-order.  If it carries data, and/or a FIN, we should store it for later processing
             // after the "hole" in the sequence number space has been filled.
             if seg_len > 0 {
@@ -998,11 +995,7 @@ impl<RT: Runtime> ControlBlock<RT> {
                 if stored_entry.0 == recv_next {
                     // Move this entry's buffer from the out-of-order store to the receive queue.
                     // This data is now considered to be "received" by TCP, and included in our RCV.NXT calculation.
-<<<<<<< HEAD
-                    info!("Recovering out-of-order packet at {}", recv_next);
-=======
                     debug!("Recovering out-of-order packet at {}", recv_next);
->>>>>>> brian-wip
                     if let Some(temp) = out_of_order.pop_front() {
                         recv_next = recv_next + SeqNumber::from(temp.1.len() as u32);
                         self.receiver.push(temp.1);
@@ -1031,11 +1024,7 @@ impl<RT: Runtime> ControlBlock<RT> {
         }
 
         // This is a lot of effort just to check the FIN sequence number is correct in debug builds.
-<<<<<<< HEAD
-        // ToDo: Consider changing all this to just "return added_out_of_order && self.out_of_order.get().is_some()".
-=======
         // ToDo: Consider changing all this to "return added_out_of_order && self.out_of_order_fin.get().is_some()".
->>>>>>> brian-wip
         if added_out_of_order {
             match self.out_of_order_fin.get() {
                 Some(fin) => {

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -449,6 +449,7 @@ impl<RT: Runtime> ControlBlock<RT> {
             // segment doesn't start precisely on RCV.NXT.
 
             // Our peer has given up.  Shut the connection down hard.
+            info!("Received RST");
             match self.state.get() {
                 // Data transfer states.
                 State::Established | State::FinWait1 | State::FinWait2 | State::CloseWait => {
@@ -599,6 +600,10 @@ impl<RT: Runtime> ControlBlock<RT> {
 
         // We can only process in-order data (or FIN).  Check for out-of-order segment.
         if seg_start != receive_next {
+<<<<<<< HEAD
+=======
+            debug!("Received out-of-order segment");
+>>>>>>> brian-wip
             // This segment is out-of-order.  If it carries data, and/or a FIN, we should store it for later processing
             // after the "hole" in the sequence number space has been filled.
             if seg_len > 0 {
@@ -639,6 +644,7 @@ impl<RT: Runtime> ControlBlock<RT> {
 
         // Check the FIN bit.
         if header.fin {
+            trace!("Received FIN");
             // ToDo: Signal the user "connection closing" and return any pending Receive requests.
 
             // Advance RCV.NXT over the FIN.
@@ -992,7 +998,11 @@ impl<RT: Runtime> ControlBlock<RT> {
                 if stored_entry.0 == recv_next {
                     // Move this entry's buffer from the out-of-order store to the receive queue.
                     // This data is now considered to be "received" by TCP, and included in our RCV.NXT calculation.
+<<<<<<< HEAD
                     info!("Recovering out-of-order packet at {}", recv_next);
+=======
+                    debug!("Recovering out-of-order packet at {}", recv_next);
+>>>>>>> brian-wip
                     if let Some(temp) = out_of_order.pop_front() {
                         recv_next = recv_next + SeqNumber::from(temp.1.len() as u32);
                         self.receiver.push(temp.1);
@@ -1021,7 +1031,11 @@ impl<RT: Runtime> ControlBlock<RT> {
         }
 
         // This is a lot of effort just to check the FIN sequence number is correct in debug builds.
+<<<<<<< HEAD
         // ToDo: Consider changing all this to just "return added_out_of_order && self.out_of_order.get().is_some()".
+=======
+        // ToDo: Consider changing all this to "return added_out_of_order && self.out_of_order_fin.get().is_some()".
+>>>>>>> brian-wip
         if added_out_of_order {
             match self.out_of_order_fin.get() {
                 Some(fin) => {

--- a/src/protocols/tcp/established/ctrlblk.rs
+++ b/src/protocols/tcp/established/ctrlblk.rs
@@ -1024,6 +1024,6 @@ impl<RT: Runtime> ControlBlock<RT> {
             }
         }
 
-        false;
+        false
     }
 }

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -122,7 +122,7 @@ impl<RT: Runtime> Sender<RT> {
             send_window: WatchedValue::new(send_window),
             send_window_last_update_seq: Cell::new(seq_no),
             send_window_last_update_ack: Cell::new(seq_no),
-        
+
             window_scale,
             mss,
 

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -39,6 +39,7 @@ pub struct UnackedSegment<RT: Runtime> {
 const UNSENT_QUEUE_CUTOFF: usize = 1024;
 
 // ToDo: Consider moving retransmit timer and congestion control fields out of this structure.
+// ToDo: Make all public fields in this structure private.
 pub struct Sender<RT: Runtime> {
     //
     // Send Sequence Space:
@@ -47,8 +48,8 @@ pub struct Sender<RT: Runtime> {
     //                     |                                                    |
     //                send_unacked               send_next         send_unacked + send window
     //                     v                         v                          v
-    // ... ----------------|-------------------------|--------------------------|------------------------------
-    //       acknowledged  |      unacknowledged     |      allowed to send     | future sequence number space
+    // ... ----------------|-------------------------|--------------------------|--------------------------------
+    //       acknowledged  |      unacknowledged     |     allowed to send      |  future sequence number space
     //
     // Note: In RFC 793 terminology, send_unacked is SND.UNA, send_next is SND.NXT, and "send window" is SND.WND.
     //

--- a/src/protocols/tcp/established/sender/mod.rs
+++ b/src/protocols/tcp/established/sender/mod.rs
@@ -256,6 +256,7 @@ impl<RT: Runtime> Sender<RT> {
                         header.fin = true;
                         buf_len = 1;
                     }
+                    trace!("Send immediate");
                     cb.emit(header, buf.clone(), remote_link_addr);
 
                     // Update SND.NXT.
@@ -291,6 +292,7 @@ impl<RT: Runtime> Sender<RT> {
         }
 
         // Slow path: Delegating sending the data to background processing.
+        trace!("Queueing Send for background processing");
         self.unsent_queue.borrow_mut().push_back(buf);
         self.unsent_seq_no.modify(|s| s + SeqNumber::from(buf_len));
 

--- a/src/protocols/tcp/tests/established.rs
+++ b/src/protocols/tcp/tests/established.rs
@@ -58,7 +58,7 @@ fn send_data(
     bytes: Bytes,
 ) -> (Bytes, usize) {
     trace!(
-        "====> push: {:?} -> {:?}",
+        "send_data ====> push: {:?} -> {:?}",
         sender.rt().local_ipv4_addr(),
         receiver.rt().local_ipv4_addr()
     );
@@ -87,7 +87,7 @@ fn send_data(
     }
     .unwrap();
 
-    trace!("====> push completed");
+    trace!("send_data ====> push completed");
 
     (bytes, bufsize)
 }
@@ -102,7 +102,7 @@ fn recv_data(
     bytes: Bytes,
 ) {
     trace!(
-        "====> pop: {:?} -> {:?}",
+        "recv_data ====> pop: {:?} -> {:?}",
         sender.rt().local_ipv4_addr(),
         receiver.rt().local_ipv4_addr()
     );
@@ -118,7 +118,7 @@ fn recv_data(
     }
     .unwrap();
 
-    trace!("====> pop completed");
+    trace!("recv_data ====> pop completed");
 }
 
 //=============================================================================
@@ -130,7 +130,7 @@ fn recv_pure_ack(
     ack_num: SeqNumber,
 ) {
     trace!(
-        "====> ack: {:?} -> {:?}",
+        "recv_pure_ack ====> ack: {:?} -> {:?}",
         sender.rt().local_ipv4_addr(),
         receiver.rt().local_ipv4_addr()
     );
@@ -150,7 +150,7 @@ fn recv_pure_ack(
         );
         receiver.receive(bytes).unwrap();
     }
-    trace!("====> ack completed");
+    trace!("recv_pure_ack ====> ack completed");
 }
 
 //=============================================================================
@@ -184,7 +184,7 @@ fn send_recv(
     // Pop data.
     recv_data(ctx, server, client, server_fd, bytes.clone());
 
-    // Pop pure ACK
+    // Pop pure ACK.
     recv_pure_ack(
         now,
         server,

--- a/src/test_helpers/engine.rs
+++ b/src/test_helpers/engine.rs
@@ -49,6 +49,7 @@ impl<RT: Runtime> Engine<RT> {
         match header.ether_type() {
             EtherType2::Arp => self.arp.receive(payload),
             EtherType2::Ipv4 => self.ipv4.receive(payload),
+            EtherType2::Ipv6 => Ok(()),  // Ignore for now.
         }
     }
 


### PR DESCRIPTION
This PR primarily fixes two major issues: the processing of ACKs we receive, and the handling of data segments we receive out of order.  We now properly handle any ACKs, and not just ones that correspond to our initial packetization.  We also now properly store out-of-order data (including potential FIN) for reinsertion into the data stream when a retransmitted or delayed packet arrives to fill the "hole" in the sequence number space (this was a potential data corruption bug).

This PR also improves when we send ACKs to be RFC 1122 compliant, how/when we update our send window, and the names of some variables to be more understandable.

This check-in contains partial or complete fixes for the Issues #63, #101, #102, #103.

*** In testing for this PR, a pre-existing bug was discovered in the retransmit() function, it removes data from the unacknowledged queue to retransmit it, when that data has not been acknowledged.  This breaks the logic tracking ACKs, etc.  So, I disabled the call to retransmit() in this PR.  I created Issue #146 to track this bug.